### PR TITLE
Default constructod in the Document calss added.

### DIFF
--- a/simple_svg_1.0.0.hpp
+++ b/simple_svg_1.0.0.hpp
@@ -659,6 +659,7 @@ namespace svg
     class Document
     {
     public:
+        Document() {};
         Document(std::string const & file_name, Layout layout = Layout())
             : file_name(file_name), layout(layout) { }
 


### PR DESCRIPTION
Hello,

I added a default constructor for the Document class. 

Now it is possible to use Document object as a field of some custom class and initialize Document instance in the object constructor, for example:

class MyClass
{
private:
   Document document;
public:
   MyClass()
      Dimensions dimensions(100, 100);
      document = Document("my_svg.svg", Layout(dimensions, Layout::BottomLeft));
}

I hope it will be helpful :)