### PR TITLE
added cap and join style to Stroke

### DIFF
--- a/main_1.0.0.cpp
+++ b/main_1.0.0.cpp
@@ -76,7 +76,7 @@ int main()
 
     doc << Rectangle(Point(70, 55), 20, 15, Color::Yellow);
 
-    Path path(Fill(), Stroke(5, Color::Blue, false, Stroke::Cap::Round, Stroke::Join::Round));
+    Path path(Fill(), Stroke(5, Color::Blue, false, Stroke::CapRound, Stroke::JoinRound));
     path << Point(0,0) << Point (10,0) << Point(10,5);
     path.offset(Point(50,60));
     doc << path;

--- a/simple_svg_1.0.0.hpp
+++ b/simple_svg_1.0.0.hpp
@@ -247,10 +247,10 @@ namespace svg
     class Stroke : public Serializeable
     {
     public:
-        enum class Cap { Butt, Round, Square };
-        enum class Join { Miter, Round, Bevel };
+        enum Cap { CapUndefined, CapButt, CapRound, CapSquare };
+        enum Join { JoinUndefined, JoinMiter, JoinRound, JoinBevel };
         Stroke(double width = -1, Color color = Color::Transparent, bool nonScalingStroke = false,
-                Cap capStyle = Cap::Butt, Join joinStyle = Join::Miter)
+                Cap capStyle = CapUndefined, Join joinStyle = JoinUndefined)
             : width(width), color(color), nonScaling(nonScalingStroke),
                 capStyle(capStyle), joinStyle(joinStyle)
         { }
@@ -265,13 +265,19 @@ namespace svg
             if (nonScaling)
                ss << attribute("vector-effect", "non-scaling-stroke");
 
-            if(capStyle == Cap::Butt) ss << attribute("stroke-linecap", "butt");
-            else if(capStyle == Cap::Round) ss << attribute("stroke-linecap", "round");
-            else if(capStyle == Cap::Square) ss << attribute("stroke-linecap", "square");
+            switch(capStyle) {
+               case CapButt : ss << attribute("stroke-linecap", "butt"); break;
+               case CapRound : ss << attribute("stroke-linecap", "round"); break;
+               case CapSquare : ss << attribute("stroke-linecap", "square"); break;
+	       default : break;
+	    }
 
-            if(joinStyle == Join::Miter) ss << attribute("stroke-linejoin", "miter");
-            else if(joinStyle == Join::Round) ss << attribute("stroke-linejoin", "round");
-            else if(joinStyle == Join::Bevel) ss << attribute("stroke-linejoin", "bevel");
+            switch(capStyle) {
+               case JoinMiter : ss << attribute("stroke-linejoin", "miter"); break;
+               case JoinRound : ss << attribute("stroke-linejoin", "round"); break;
+               case JoinBevel : ss << attribute("stroke-linejoin", "bevel"); break;
+	       default : break;
+            }
 
             return ss.str();
         }


### PR DESCRIPTION
I made a small enhancement to the Stroke class, that allows to specify the styles for caps and line joins as additional arguments to the constructor. The previous behavior is preserved. The main.cpp now has a little demo object for it with round joins.