### PR TITLE
Revise demo, add tests, apply cppcheck

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,12 @@
-project (simple-svg)
 cmake_minimum_required(VERSION 2.8)
+project(simple-svg)
 
 add_executable(simple_svg main_1.0.0.cpp simple_svg_1.0.0.hpp)
 
 set_property(TARGET simple_svg PROPERTY CXX_STANDARD 11)
 
-                     
 if(MSVC)
-   add_definitions(/D_CRT_SECURE_NO_WARNINGS)
-   add_definitions(/D_SCL_SECURE_NO_WARNINGS)
-   add_definitions(/DNOMINMAX)
+    add_definitions(/D_CRT_SECURE_NO_WARNINGS)
+    add_definitions(/D_SCL_SECURE_NO_WARNINGS)
+    add_definitions(/DNOMINMAX)
 endif(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 project(simple-svg)
 
+# Enable testing
+enable_testing()
+
+# Add the main executable
 add_executable(simple_svg main_1.0.0.cpp simple_svg_1.0.0.hpp)
 
 set_property(TARGET simple_svg PROPERTY CXX_STANDARD 11)
@@ -10,3 +14,14 @@ if(MSVC)
     add_definitions(/D_SCL_SECURE_NO_WARNINGS)
     add_definitions(/DNOMINMAX)
 endif(MSVC)
+
+# Add Google Test
+find_package(GTest REQUIRED)
+include_directories(${GTEST_INCLUDE_DIRS})
+
+# Add the test executable
+add_executable(simple_svg_test tests/simple_svg_test.cpp simple_svg_1.0.0.hpp)
+target_link_libraries(simple_svg_test ${GTEST_LIBRARIES} pthread)
+
+# Add the test
+add_test(NAME SimplesvgTest COMMAND simple_svg_test)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # simple-svg
+
 Easy to use SVG library for C++ (fork)
 
 This library is a single file header-only C++ library for creating SVG files.
@@ -7,5 +8,37 @@ Simple-SVG was written to provide an easy API to allow beginners to become more 
 
 This project creates files that can then be viewed by a sister project [File Monitor](http://code.google.com/p/file-monitor). As you make changes to your SVG document, you will automatically see an updated image in File Monitor.
 
-
 This is a fork/clone of the original code [here](https://code.google.com/p/simple-svg/).
+
+## Build Instructions
+
+```
+mkdir build
+cd build
+cmake ..
+make
+```
+
+This will create the demo executable `simple_svg` and the test executable `simple_svg_test`, and run the tests.
+
+You can run the demo with:
+
+```
+simple_svg
+```
+
+to create a demo SVG file, `my_svg.svg`.
+
+You can run the tests with:
+
+```
+ctest
+```
+
+or with
+
+```
+simple_svg_test
+```
+
+to see the details of the tests.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ simple_svg_test
 ```
 
 to see the details of the tests.
+
+## Code modifications to satisfy `cppcheck`
+
+Running `cppcheck` on the code:
+```
+cppcheck --enable=style --check-level=exhaustive main_1.0.0.cpp
+```
+
+produced errors against the `cppcheck` ruleset.
+
+These errors were fixed by making `explicit` constructors for Dimensions, Point, Layout, Color
+and updating code that uses these classes.

--- a/main_1.0.0.cpp
+++ b/main_1.0.0.cpp
@@ -38,8 +38,9 @@ using namespace svg;
 
 int main()
 {
-    Dimensions dimensions(100, 100);
-    Document doc("my_svg.svg", Layout(dimensions, Layout::BottomLeft));
+    std::string filename = "my_svg.svg";
+    Dimensions dimensions(500, 500);
+    Document doc(filename, Layout(dimensions, Layout::BottomLeft));
 
     // Red image border.
     Polygon border(Stroke(1, Color::Red));
@@ -47,34 +48,38 @@ int main()
         << Point(dimensions.width, dimensions.height) << Point(0, dimensions.height);
     doc << border;
 
-    // Long notation.  Local variable is created, children are added to varaible.
-    LineChart chart(5.0);
-    Polyline polyline_a(Stroke(.5, Color::Blue));
-    Polyline polyline_b(Stroke(.5, Color::Aqua));
-    Polyline polyline_c(Stroke(.5, Color::Fuchsia));
-    polyline_a << Point(0, 0) << Point(10, 30)
-        << Point(20, 40) << Point(30, 45) << Point(40, 44);
-    polyline_b << Point(0, 10) << Point(10, 22)
-        << Point(20, 30) << Point(30, 32) << Point(40, 30);
-    polyline_c << Point(0, 12) << Point(10, 15)
-        << Point(20, 14) << Point(30, 10) << Point(40, 2);
+    // Long notation.  Local variable is created, children are added to variable.
+    LineChart chart(12.5);
+    Polyline polyline_a(Stroke(1.25, Color::Blue));
+    Polyline polyline_b(Stroke(1.25, Color::Aqua));
+    Polyline polyline_c(Stroke(1.25, Color::Fuchsia));
+    polyline_a << Point(0, 0) << Point(25, 75)
+        << Point(50, 100) << Point(75, 112.5) << Point(100, 110);
+    polyline_b << Point(0, 25) << Point(25, 55)
+        << Point(50, 75) << Point(75, 80) << Point(100, 75);
+    polyline_c << Point(0, 30) << Point(25, 37.5)
+        << Point(50, 35) << Point(75, 25) << Point(100, 5);
     chart << polyline_a << polyline_b << polyline_c;
     doc << chart;
 
     // Condensed notation, parenthesis isolate temporaries that are inserted into parents.
-    doc << (LineChart(Dimensions(65, 5))
-        << (Polyline(Stroke(.5, Color::Blue)) << Point(0, 0) << Point(10, 8) << Point(20, 13))
-        << (Polyline(Stroke(.5, Color::Orange)) << Point(0, 10) << Point(10, 16) << Point(20, 20))
-        << (Polyline(Stroke(.5, Color::Cyan)) << Point(0, 5) << Point(10, 13) << Point(20, 16)));
+    doc << (LineChart(Dimensions(162.5, 12.5))
+        << (Polyline(Stroke(1.25, Color::Blue)) << Point(0, 0) << Point(25, 20) << Point(50, 32.5))
+        << (Polyline(Stroke(1.25, Color::Orange)) << Point(0, 25) << Point(25, 40) << Point(50, 50))
+        << (Polyline(Stroke(1.25, Color::Cyan)) << Point(0, 12.5) << Point(25, 32.5) << Point(50, 40)));
 
-    doc << Circle(Point(80, 80), 20, Fill(Color(100, 200, 120)), Stroke(1, Color(200, 250, 150)));
+    doc << Circle(Point(200, 200), 50, Fill(Color(100, 200, 120)), Stroke(2.5, Color(200, 250, 150)));
 
-    doc << Text(Point(5, 77), "Simple SVG", Color::Silver, Font(10, "Verdana"));
+    doc << Text(Point(12.5, 192.5), "Simple SVG", Color::Silver, Font(25, "Verdana"));
 
-    doc << (Polygon(Color(200, 160, 220), Stroke(.5, Color(150, 160, 200))) << Point(20, 70)
-        << Point(25, 72) << Point(33, 70) << Point(35, 60) << Point(25, 55) << Point(18, 63));
+    doc << (Polygon(Color(200, 160, 220), Stroke(1.25, Color(150, 160, 200))) << Point(50, 175)
+        << Point(62.5, 180) << Point(82.5, 175) << Point(87.5, 150) << Point(62.5, 137.5) << Point(45, 157.5));
 
-    doc << Rectangle(Point(70, 55), 20, 15, Color::Yellow);
+    doc << Rectangle(Point(175, 137.5), 50, 37.5, Color::Yellow);
 
-    doc.save();
+    if (doc.save()) {
+        std::cout << "File saved successfully: " << filename << std::endl;
+    } else {
+        std::cout << "Failed to save the file: " << filename << std::endl;
+    }
 }

--- a/main_1.0.0.cpp
+++ b/main_1.0.0.cpp
@@ -49,7 +49,7 @@ int main()
     doc << border;
 
     // Long notation.  Local variable is created, children are added to variable.
-    LineChart chart(12.5);
+    LineChart chart(Dimensions(12.5, 12.5));
     Polyline polyline_a(Stroke(1.25, Color::Blue));
     Polyline polyline_b(Stroke(1.25, Color::Aqua));
     Polyline polyline_c(Stroke(1.25, Color::Fuchsia));
@@ -70,12 +70,12 @@ int main()
 
     doc << Circle(Point(200, 200), 50, Fill(Color(100, 200, 120)), Stroke(2.5, Color(200, 250, 150)));
 
-    doc << Text(Point(12.5, 192.5), "Simple SVG", Color::Silver, Font(25, "Verdana"));
+    doc << Text(Point(12.5, 192.5), "Simple SVG", Fill(Color::Silver), Font(25, "Verdana"));
 
-    doc << (Polygon(Color(200, 160, 220), Stroke(1.25, Color(150, 160, 200))) << Point(50, 175)
+    doc << (Polygon(Fill(Color(200, 160, 220)), Stroke(1.25, Color(150, 160, 200))) << Point(50, 175)
         << Point(62.5, 180) << Point(82.5, 175) << Point(87.5, 150) << Point(62.5, 137.5) << Point(45, 157.5));
 
-    doc << Rectangle(Point(175, 137.5), 50, 37.5, Color::Yellow);
+    doc << Rectangle(Point(175, 137.5), 50, 37.5, Fill(Color::Yellow), Stroke(1, Color::Black));
 
     if (doc.save()) {
         std::cout << "File saved successfully: " << filename << std::endl;

--- a/simple_svg_1.0.0.hpp
+++ b/simple_svg_1.0.0.hpp
@@ -101,6 +101,15 @@ namespace svg
         Point(double x = 0, double y = 0) : x(x), y(y) { }
         double x;
         double y;
+
+        Point operator+(const Point& other) const {
+            return Point(x + other.x, y + other.y);
+        }
+
+        Point operator-(const Point &other) const
+        {
+            return Point(x - other.x, y - other.y);
+        }
     };
     inline optional<Point> getMinPoint(std::vector<Point> const & points)
     {
@@ -307,9 +316,9 @@ namespace svg
     class Circle : public Shape
     {
     public:
-        Circle(Point const & center, double diameter, Fill const & fill,
-            Stroke const & stroke = Stroke())
-            : Shape(fill, stroke), center(center), radius(diameter / 2) { }
+        Circle(Point const &center, double diameter, Fill const &fill = Fill(),
+               Stroke const &stroke = Stroke())
+            : Shape(fill, stroke), center(center), radius(diameter / 2) {}
         std::string toString(Layout const & layout) const
         {
             std::stringstream ss;
@@ -454,9 +463,9 @@ namespace svg
     {
     public:
        Path(Fill const & fill = Fill(), Stroke const & stroke = Stroke())
-          : Shape(fill, stroke) 
+          : Shape(fill, stroke)
        {  startNewSubPath(); }
-       Path(Stroke const & stroke = Stroke()) : Shape(Color::Transparent, stroke) 
+       Path(Stroke const & stroke = Stroke()) : Shape(Color::Transparent, stroke)
        {  startNewSubPath(); }
        Path & operator<<(Point const & point)
        {

--- a/tests/simple_svg_test.cpp
+++ b/tests/simple_svg_test.cpp
@@ -1,0 +1,241 @@
+// TEST
+// TEST is used to define a simple test case.
+// It does not require any setup or teardown code.
+// It is suitable for tests that do not need to share common setup or state.
+
+// TEST_F
+// TEST_F is used to define a test case that uses a test fixture.
+// A test fixture is a class derived from ::testing::Test that provides common setup and teardown code for multiple tests.
+// It is suitable for tests that need to share common setup, state, or helper functions.
+
+#include <gtest/gtest.h>
+#include "../simple_svg_1.0.0.hpp"
+#include <sstream>
+
+using namespace svg;
+
+// SVGTest -----------------------------------------------------------------------------------------
+
+class SVGTest : public ::testing::Test
+{
+protected:
+    Layout layout;
+
+    void SetUp() override
+    {
+        layout = Layout(Dimensions(100, 100), Layout::TopLeft);
+    }
+};
+
+TEST_F(SVGTest, ShapeTest)
+{
+    Circle circle(Point(50, 50), 20, Fill(Color::Red), Stroke(2, Color::Blue));
+    std::string circleStr = circle.toString(layout);
+
+    // std::cout << "ShapeTest circleStr: " << circleStr << std::endl;
+
+    EXPECT_TRUE(circleStr.find("cx=\"50\"") != std::string::npos);
+    EXPECT_TRUE(circleStr.find("cy=\"50\"") != std::string::npos);
+    EXPECT_TRUE(circleStr.find("r=\"10\"") != std::string::npos);
+    EXPECT_TRUE(circleStr.find("fill=\"rgb(255,0,0)\"") != std::string::npos);
+    EXPECT_TRUE(circleStr.find("stroke=\"rgb(0,0,255)\"") != std::string::npos);
+}
+
+TEST_F(SVGTest, PolygonTest)
+{
+    Polygon polygon(Fill(Color::Green), Stroke(1, Color::Black));
+    polygon << Point(0, 0) << Point(100, 0) << Point(100, 100) << Point(0, 100);
+    std::string polygonStr = polygon.toString(layout);
+    EXPECT_TRUE(polygonStr.find("points=\"0,0 100,0 100,100 0,100 \"") != std::string::npos);
+    EXPECT_TRUE(polygonStr.find("fill=\"rgb(0,128,0)\"") != std::string::npos);
+    EXPECT_TRUE(polygonStr.find("stroke=\"rgb(0,0,0)\"") != std::string::npos);
+}
+
+TEST_F(SVGTest, TextTest)
+{
+    Text text(Point(10, 20), "Hello SVG", Fill(Color::Black), Font(12, "Arial"));
+    std::string textStr = text.toString(layout);
+    EXPECT_TRUE(textStr.find("x=\"10\"") != std::string::npos);
+    EXPECT_TRUE(textStr.find("y=\"20\"") != std::string::npos);
+    EXPECT_TRUE(textStr.find("font-size=\"12\"") != std::string::npos);
+    EXPECT_TRUE(textStr.find("font-family=\"Arial\"") != std::string::npos);
+    EXPECT_TRUE(textStr.find(">Hello SVG<") != std::string::npos);
+}
+
+TEST_F(SVGTest, LineChartTest)
+{
+    LineChart chart;
+    Polyline line1(Stroke(1, Color::Blue));
+    line1 << Point(0, 0) << Point(10, 10) << Point(20, 20);
+    chart << line1;
+
+    Polyline line2(Stroke(1, Color::Red));
+    line2 << Point(0, 20) << Point(10, 10) << Point(20, 0);
+    chart << line2;
+
+    std::string chartStr = chart.toString(layout);
+    EXPECT_TRUE(chartStr.find("stroke=\"rgb(0,0,255)\"") != std::string::npos);
+    EXPECT_TRUE(chartStr.find("stroke=\"rgb(255,0,0)\"") != std::string::npos);
+    EXPECT_TRUE(chartStr.find("points=\"0,0 10,10 20,20 \"") != std::string::npos);
+    EXPECT_TRUE(chartStr.find("points=\"0,20 10,10 20,0 \"") != std::string::npos);
+}
+
+TEST_F(SVGTest, DocumentTest)
+{
+    Document doc("test.svg", Layout(Dimensions(200, 200)));
+    doc << Circle(Point(100, 100), 50, Fill(Color::Red));
+    doc << Text(Point(10, 20), "Test SVG", Fill(Color::Black));
+
+    std::string docStr = doc.toString();
+
+    // std::cout << "DocumentTest SVG:\n"
+    //           << docStr << std::endl;
+
+    EXPECT_TRUE(docStr.find("<svg width=\"200px\" height=\"200px\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("<circle cx=\"100\" cy=\"100\" r=\"25\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("<text x=\"10\" y=\"180\" fill=\"rgb(0,0,0)\"") != std::string::npos);
+}
+
+TEST_F(SVGTest, PathTest)
+{
+    Document doc;
+    Path path(Fill(Color::Yellow), Stroke(2, Color::Purple));
+    path << Point(0, 0) << Point(100, 0) << Point(100, 100);
+    path.startNewSubPath();
+    path << Point(0, 100) << Point(0, 0);
+    doc << path;
+    std::string docStr = doc.toString();
+
+    // std::cout << "PathTest SVG:\n"
+    //           << docStr << std::endl;
+
+    EXPECT_TRUE(docStr.find("<path") != std::string::npos);
+    EXPECT_TRUE(docStr.find("d=\"M0,300 100,300 100,200 z M0,200 0,300 z \"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("fill=\"rgb(255,255,0)\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("stroke=\"rgb(128,0,128)\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("stroke-width=\"2\"") != std::string::npos);
+}
+
+TEST_F(SVGTest, ColorTest2)
+{
+    Color color(128, 64, 32);
+    EXPECT_EQ(color.toString(layout), "rgb(128,64,32)");
+}
+
+TEST_F(SVGTest, LayoutTest)
+{
+    Layout layoutTopLeft(Dimensions(200, 200), Layout::TopLeft);
+    Layout layoutBottomLeft(Dimensions(200, 200), Layout::BottomLeft);
+
+    Circle circle(Point(100, 100), 50);
+
+    std::string circleStrTopLeft = circle.toString(layoutTopLeft);
+    std::string circleStrBottomLeft = circle.toString(layoutBottomLeft);
+
+    EXPECT_TRUE(circleStrTopLeft.find("cy=\"100\"") != std::string::npos);
+    EXPECT_TRUE(circleStrBottomLeft.find("cy=\"100\"") != std::string::npos);
+}
+
+// SimpleSvgTest -----------------------------------------------------------------------------------
+
+TEST(SimpleSvgTest, TextTest)
+{
+    Document doc;
+    doc << Text(Point(10, 20), "Hello, SVG!", Fill(Color::Black), Font(12, "Arial"));
+    std::string docStr = doc.toString();
+
+    // std::cout << "TextTest SVG:\n"
+    //           << docStr << std::endl;
+
+    EXPECT_TRUE(docStr.find("<text x=\"10\" y=\"280\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("font-size=\"12\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("font-family=\"Arial\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find(">Hello, SVG!</text>") != std::string::npos);
+}
+
+TEST(SimpleSvgTest, CircleTest)
+{
+    Document doc;
+    doc << Circle(Point(100, 100), 50, Fill(Color::Red), Stroke(2, Color::Blue));
+    std::string docStr = doc.toString();
+
+    // std::cout << "CircleTest SVG:\n"
+    //           << docStr << std::endl;
+
+    EXPECT_TRUE(docStr.find("<circle cx=\"100\" cy=\"200\" r=\"25\"") != std::string::npos); // WHY cy="200"?
+    EXPECT_TRUE(docStr.find("fill=\"rgb(255,0,0)\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("stroke=\"rgb(0,0,255)\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("stroke-width=\"2\"") != std::string::npos);
+}
+
+TEST(SimpleSvgTest, PolygonTest)
+{
+    Document doc;
+    Polygon polygon(Fill(Color::Green), Stroke(1, Color::Black));
+    polygon << Point(0, 0) << Point(100, 0) << Point(100, 100) << Point(0, 100);
+    doc << polygon;
+
+    std::string docStr = doc.toString();
+
+    // std::cout << "PolygonTest SVG:\n"
+    //           << docStr << std::endl;
+
+    EXPECT_TRUE(docStr.find("<polygon points=\"0,300 100,300 100,200 0,200 \"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("fill=\"rgb(0,128,0)\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("stroke=\"rgb(0,0,0)\"") != std::string::npos);
+}
+
+TEST(SimpleSvgTest, LineChartTest)
+{
+    Document doc;
+    LineChart chart;
+    Polyline line1(Stroke(1, Color::Blue));
+    line1 << Point(0, 0) << Point(10, 10) << Point(20, 20);
+    Polyline line2(Stroke(1, Color::Red));
+    line2 << Point(0, 20) << Point(10, 10) << Point(20, 0);
+    chart << line1 << line2;
+    doc << chart;
+    std::string docStr = doc.toString();
+    EXPECT_TRUE(docStr.find("<polyline") != std::string::npos);
+    EXPECT_TRUE(docStr.find("stroke=\"rgb(0,0,255)\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("stroke=\"rgb(255,0,0)\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("<circle") != std::string::npos); // Vertices
+}
+
+TEST(SimpleSvgTest, StrokeTest)
+{
+    Stroke stroke(3, Color::Blue, true);
+    Document doc;
+    doc << Rectangle(Point(0, 0), 100, 100, Fill(), stroke);
+    std::string docStr = doc.toString();
+
+    // std::cout << "StrokeTest SVG:\n"
+    //           << docStr << std::endl;
+
+    EXPECT_TRUE(docStr.find("rect x=\"0\" y=\"300\" width=\"100\" height=\"100\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("height=\"100\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("fill=\"none\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("stroke-width=\"3\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("stroke=\"rgb(0,0,255)\"") != std::string::npos);
+}
+
+TEST(SimpleSvgTest, PointTest)
+{
+    Point p1(10, 20);
+    Point p2(5, 8);
+
+    Point sum = p1 + p2;
+    Point diff = p1 - p2;
+
+    EXPECT_EQ(sum.x, 15);
+    EXPECT_EQ(sum.y, 28);
+    EXPECT_EQ(diff.x, 5);
+    EXPECT_EQ(diff.y, 12);
+}
+
+// Run the tests -----------------------------------------------------------------------------------
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- in `main_1.0.0.cpp` simple_svg demo code: scale up the drawings and add messages to the user

- in `simple_svg_1.0.0.hpp` add Point operators +, -; Circle cst: add default value for fill

- add gtests in new file `tests/simple_svg_test.cpp`

- update `CMakeLists.txt` to handle tests

- in `simple_svg_1.0.0.hpp`: make constructors explicit for classes `Dimensions`, `Point`, `Layout`, `Color`, to avoid ambiguities when reading the calling code