### PR TITLE
Revise demos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ build/
 *.exe
 *.out
 *.app
+
+# Mac OSX
+.DS_Store

--- a/main_1.0.0.cpp
+++ b/main_1.0.0.cpp
@@ -34,21 +34,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace svg;
 
-// Demo page shows sample usage of the Simple SVG library.
+ShapeColl createSVGElements() {
+    std::cout << "Creating SVG elements..." << std::endl;
 
-int main()
-{
-    std::string filename = "my_svg.svg";
-    Dimensions dimensions(500, 500);
-    Document doc(filename, Layout(dimensions, Layout::BottomLeft));
+    ShapeColl elements;
 
-    // Red image border.
-    Polygon border(Stroke(1, Color::Red));
-    border << Point(0, 0) << Point(dimensions.width, 0)
-        << Point(dimensions.width, dimensions.height) << Point(0, dimensions.height);
-    doc << border;
-
-    // Long notation.  Local variable is created, children are added to variable.
+    // Long notation
     LineChart chart(Dimensions(12.5, 12.5));
     Polyline polyline_a(Stroke(1.25, Color::Blue));
     Polyline polyline_b(Stroke(1.25, Color::Aqua));
@@ -60,26 +51,76 @@ int main()
     polyline_c << Point(0, 30) << Point(25, 37.5)
         << Point(50, 35) << Point(75, 25) << Point(100, 5);
     chart << polyline_a << polyline_b << polyline_c;
-    doc << chart;
+    elements << chart;
 
-    // Condensed notation, parenthesis isolate temporaries that are inserted into parents.
-    doc << (LineChart(Dimensions(162.5, 12.5))
+    // Condensed notation
+    elements << (LineChart(Dimensions(162.5, 12.5))
         << (Polyline(Stroke(1.25, Color::Blue)) << Point(0, 0) << Point(25, 20) << Point(50, 32.5))
         << (Polyline(Stroke(1.25, Color::Orange)) << Point(0, 25) << Point(25, 40) << Point(50, 50))
         << (Polyline(Stroke(1.25, Color::Cyan)) << Point(0, 12.5) << Point(25, 32.5) << Point(50, 40)));
 
-    doc << Circle(Point(200, 200), 50, Fill(Color(100, 200, 120)), Stroke(2.5, Color(200, 250, 150)));
+    elements << Circle(Point(200, 200), 50, Fill(Color(100, 200, 120)), Stroke(2.5, Color(200, 250, 150)));
 
-    doc << Text(Point(12.5, 192.5), "Simple SVG", Fill(Color::Silver), Font(25, "Verdana"));
+    elements << Text(Point(12.5, 192.5), "Simple SVG", Fill(Color::Silver), Font(25, "Verdana"));
 
-    doc << (Polygon(Fill(Color(200, 160, 220)), Stroke(1.25, Color(150, 160, 200))) << Point(50, 175)
+    elements << (Polygon(Fill(Color(200, 160, 220)), Stroke(1.25, Color(150, 160, 200))) << Point(50, 175)
         << Point(62.5, 180) << Point(82.5, 175) << Point(87.5, 150) << Point(62.5, 137.5) << Point(45, 157.5));
 
-    doc << Rectangle(Point(175, 137.5), 50, 37.5, Fill(Color::Yellow), Stroke(1, Color::Black));
+    elements << Rectangle(Point(175, 137.5), 50, 37.5, Fill(Color::Yellow), Stroke(1, Color::Black));
 
-    if (doc.save()) {
-        std::cout << "File saved successfully: " << filename << std::endl;
-    } else {
-        std::cout << "Failed to save the file: " << filename << std::endl;
+    std::cout << "SVG elements created successfully." << std::endl;
+    return elements;
+}
+
+// Demo page shows sample usage of the Simple SVG library.
+
+
+int main()
+{
+    try
+    {
+        std::cout << "Starting main function..." << std::endl;
+
+        std::string filename = "my_svg.svg";
+        Dimensions dimensions(500, 500);
+
+        std::cout << "Creating Document..." << std::endl;
+        Document doc(filename, Layout(dimensions, Layout::BottomLeft));
+
+        std::cout << "Creating border..." << std::endl;
+        Polygon border(Stroke(1, Color::Red));
+        border << Point(0, 0) << Point(dimensions.width, 0)
+               << Point(dimensions.width, dimensions.height) << Point(0, dimensions.height);
+
+        std::cout << "Adding border to document..." << std::endl;
+        doc << border;
+
+        std::cout << "Creating SVG elements..." << std::endl;
+        ShapeColl elements = createSVGElements();
+
+        std::cout << "Adding elements to document..." << std::endl;
+        doc << elements;
+
+        std::cout << "Saving document..." << std::endl;
+        if (doc.save())
+        {
+            std::cout << "File saved successfully: " << filename << std::endl;
+        }
+        else
+        {
+            std::cout << "Failed to save the file: " << filename << std::endl;
+        }
+
+        std::cout << "Main function completed successfully." << std::endl;
     }
+    catch (const std::exception &e)
+    {
+        std::cerr << "An exception occurred: " << e.what() << std::endl;
+    }
+    catch (...)
+    {
+        std::cerr << "An unknown exception occurred." << std::endl;
+    }
+
+    return 0;
 }

--- a/main_1.0.0.cpp
+++ b/main_1.0.0.cpp
@@ -35,83 +35,124 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace svg;
 
 ShapeColl createSVGElements() {
-    std::cout << "Creating SVG elements..." << std::endl;
-
     ShapeColl elements;
 
-    // Long notation
+    // Create a LineChart with Long notation
     LineChart chart(Dimensions(12.5, 12.5));
+
+    // Create three Polylines with different colors and strokes
     Polyline polyline_a(Stroke(1.25, Color::Blue));
     Polyline polyline_b(Stroke(1.25, Color::Aqua));
     Polyline polyline_c(Stroke(1.25, Color::Fuchsia));
+
+    // Add points to each polyline
     polyline_a << Point(0, 0) << Point(25, 75)
         << Point(50, 100) << Point(75, 112.5) << Point(100, 110);
     polyline_b << Point(0, 25) << Point(25, 55)
         << Point(50, 75) << Point(75, 80) << Point(100, 75);
     polyline_c << Point(0, 30) << Point(25, 37.5)
         << Point(50, 35) << Point(75, 25) << Point(100, 5);
+
+    // Add the polylines to the chart
     chart << polyline_a << polyline_b << polyline_c;
+
+    // Add the chart to the elements collection
     elements << chart;
 
-    // Condensed notation
+    // Create and add another LineChart with Condensed notation
     elements << (LineChart(Dimensions(162.5, 12.5))
         << (Polyline(Stroke(1.25, Color::Blue)) << Point(0, 0) << Point(25, 20) << Point(50, 32.5))
         << (Polyline(Stroke(1.25, Color::Orange)) << Point(0, 25) << Point(25, 40) << Point(50, 50))
         << (Polyline(Stroke(1.25, Color::Cyan)) << Point(0, 12.5) << Point(25, 32.5) << Point(50, 40)));
 
+    // Create and add a Circle with specific properties
     elements << Circle(Point(200, 200), 50, Fill(Color(100, 200, 120)), Stroke(2.5, Color(200, 250, 150)));
 
+    // Create and add a Text element with specific properties
     elements << Text(Point(12.5, 192.5), "Simple SVG", Fill(Color::Silver), Font(25, "Verdana"));
 
+    // Create and add a Polygon with specific properties
     elements << (Polygon(Fill(Color(200, 160, 220)), Stroke(1.25, Color(150, 160, 200))) << Point(50, 175)
         << Point(62.5, 180) << Point(82.5, 175) << Point(87.5, 150) << Point(62.5, 137.5) << Point(45, 157.5));
 
+    // Create and add a Rectangle with specific properties
     elements << Rectangle(Point(175, 137.5), 50, 37.5, Fill(Color::Yellow), Stroke(1, Color::Black));
 
-    std::cout << "SVG elements created successfully." << std::endl;
+    // Return the collection of SVG elements
     return elements;
 }
 
 // Demo page shows sample usage of the Simple SVG library.
 
+void demoDocLayout(const Layout &layout)
+{
+    // Generate filename based on the layout origin type
+    std::string filename;
+    switch (layout.origin)
+    {
+    case Layout::TopLeft:
+        filename = "svg_topleft.svg";
+        break;
+    case Layout::TopRight:
+        filename = "svg_topright.svg";
+        break;
+    case Layout::BottomLeft:
+        filename = "svg_bottomleft.svg";
+        break;
+    case Layout::BottomRight:
+        filename = "svg_bottomright.svg";
+        break;
+    }
+
+    // Create SVG document with specified layout
+    Document doc(filename, layout);
+
+    // Draw border rectangle using document dimensions
+    Polygon border(Stroke(1, Color::Red));
+    border << Point(0, 0) << Point(layout.dimensions.width, 0)
+           << Point(layout.dimensions.width, layout.dimensions.height)
+           << Point(0, layout.dimensions.height);
+    doc << border;
+
+    // Mark origin and the farthest point in the layout with circles
+    doc << Circle(Point(0, 0), 20, Fill(Color::Red), Stroke(1, Color::Black));
+    doc << Circle(Point(layout.dimensions.width - 10, layout.dimensions.height - 10), 20, Fill(Color::Red), Stroke(1, Color::Black));
+
+    // Create and add all demo shapes
+    ShapeColl elements = createSVGElements();
+    doc << elements;
+
+    // Save document and report status
+    if (doc.save())
+    {
+        std::cout << "File saved successfully: " << filename << std::endl;
+    }
+    else
+    {
+        std::cout << "Failed to save the file: " << filename << std::endl;
+    }
+}
 
 int main()
 {
     try
     {
-        std::cout << "Starting main function..." << std::endl;
-
-        std::string filename = "my_svg.svg";
+        // Set canvas dimensions for all layouts
         Dimensions dimensions(500, 500);
 
-        std::cout << "Creating Document..." << std::endl;
-        Document doc(filename, Layout(dimensions, Layout::BottomLeft));
+        // Define array of all possible coordinate system origins
+        Layout::Origin layouts[] = {
+            Layout::TopLeft,
+            Layout::TopRight,
+            Layout::BottomLeft,
+            Layout::BottomRight};
 
-        std::cout << "Creating border..." << std::endl;
-        Polygon border(Stroke(1, Color::Red));
-        border << Point(0, 0) << Point(dimensions.width, 0)
-               << Point(dimensions.width, dimensions.height) << Point(0, dimensions.height);
-
-        std::cout << "Adding border to document..." << std::endl;
-        doc << border;
-
-        std::cout << "Creating SVG elements..." << std::endl;
-        ShapeColl elements = createSVGElements();
-
-        std::cout << "Adding elements to document..." << std::endl;
-        doc << elements;
-
-        std::cout << "Saving document..." << std::endl;
-        if (doc.save())
+        // Generate SVG file for each coordinate system origin
+        for (Layout::Origin origin : layouts)
         {
-            std::cout << "File saved successfully: " << filename << std::endl;
+            Layout layout(dimensions, origin);
+            demoDocLayout(layout);
         }
-        else
-        {
-            std::cout << "Failed to save the file: " << filename << std::endl;
-        }
-
-        std::cout << "Main function completed successfully." << std::endl;
     }
     catch (const std::exception &e)
     {
@@ -121,6 +162,5 @@ int main()
     {
         std::cerr << "An unknown exception occurred." << std::endl;
     }
-
     return 0;
 }

--- a/tests/simple_svg_test.cpp
+++ b/tests/simple_svg_test.cpp
@@ -27,12 +27,28 @@ protected:
     }
 };
 
-TEST_F(SVGTest, ShapeTest)
+TEST_F(SVGTest,  ShapeCollTest)
+{
+    ShapeColl ShapeColl;
+    std::string sercollStr = ShapeColl.toString(layout);
+
+    // std::cout << "* ShapeCollTest sercollStr: " << sercollStr << std::endl;
+    EXPECT_TRUE(sercollStr.empty());
+
+    ShapeColl << Text(Point(10, 20), "Hello, SVG!", Fill(Color::Black), Font(12, "Arial"));
+
+    std::string expectedStr = "\t<text x=\"10\" y=\"20\" fill=\"rgb(0,0,0)\" font-size=\"12\" font-family=\"Arial\" >Hello, SVG!</text>\n";
+    sercollStr = ShapeColl.toString(layout);
+    // std::cout << "* ShapeCollTest sercollStr: " << sercollStr << std::endl;
+    EXPECT_EQ(sercollStr, expectedStr);
+}
+
+TEST_F(SVGTest, Shape2Test)
 {
     Circle circle(Point(50, 50), 20, Fill(Color::Red), Stroke(2, Color::Blue));
     std::string circleStr = circle.toString(layout);
 
-    // std::cout << "ShapeTest circleStr: " << circleStr << std::endl;
+    // std::cout << "* Shape2Test circleStr: " << circleStr << std::endl;
 
     EXPECT_TRUE(circleStr.find("cx=\"50\"") != std::string::npos);
     EXPECT_TRUE(circleStr.find("cy=\"50\"") != std::string::npos);


### PR DESCRIPTION
I added `class ShapeColl` into which any number of other `Shape` instances can be streamed, and which streams out the resulting multiline svg string.

This enabled the creation of demos of same example svg objects with different layout origins.

These demos (in the `main_1.0.0.cpp`) demonstrate problems with displaying `Text` and `Rectangle` in some layouts, which require further work. 

See also:
```
TEST_F(SVGTest,  ShapeCollTest)
```