### PR TITLE
Rectangle and Text: fix the positions in each Layout; add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: Google
+BreakBeforeBraces: Allman
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 80
+LineEnding: LF

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Get a list of all staged .hpp and .cpp files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(hpp|cpp)$')
+
+# Apply clang-format to each staged file
+for FILE in $STAGED_FILES; do
+    clang-format -style=file -i "$FILE"
+    git add "$FILE"
+done
+
+# Continue with the commit
+exit 0

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ to create a demo SVG file, `my_svg.svg`.
 You can run the tests with:
 
 ```
-ctest
+ctest               # brief info on success or failure
 ```
 
 or with
 
 ```
-simple_svg_test
+simple_svg_test     # detailed info on success or failure
 ```
 
 to see the details of the tests.
@@ -46,6 +46,7 @@ to see the details of the tests.
 ## Code modifications to satisfy `cppcheck`
 
 Running `cppcheck` on the code:
+
 ```
 cppcheck --enable=style --check-level=exhaustive main_1.0.0.cpp
 ```
@@ -54,3 +55,33 @@ produced errors against the `cppcheck` ruleset.
 
 These errors were fixed by making `explicit` constructors for Dimensions, Point, Layout, Color
 and updating code that uses these classes.
+
+## Classes available from the library
+
+```
+Color - Serializable
+Fill - Serializable
+Stroke - Serializable
+Font - Serializable
+ShapeColl - Shape
+Circle - Shape
+Elipse - Shape
+Rectangle - Shape
+Line - Shape
+Polygon - Shape
+Path - Shape
+Polyline - Shape
+Text - Shape
+LineChart - Shape
+Document - Neither
+```
+
+A `Document` instance creates a svg file.
+
+You can add any number of Shape instances to the document.
+
+You use the serializable classes to set the properties of the shapes.
+
+## Example usage
+
+See demo code in `main_1.0.0.cpp` for example usage.

--- a/main_1.0.0.cpp
+++ b/main_1.0.0.cpp
@@ -34,7 +34,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace svg;
 
-ShapeColl createSVGElements() {
+ShapeColl createSVGElements()
+{
     ShapeColl elements;
 
     // Create a LineChart with Long notation
@@ -46,12 +47,12 @@ ShapeColl createSVGElements() {
     Polyline polyline_c(Stroke(1.25, Color::Fuchsia));
 
     // Add points to each polyline
-    polyline_a << Point(0, 0) << Point(25, 75)
-        << Point(50, 100) << Point(75, 112.5) << Point(100, 110);
-    polyline_b << Point(0, 25) << Point(25, 55)
-        << Point(50, 75) << Point(75, 80) << Point(100, 75);
-    polyline_c << Point(0, 30) << Point(25, 37.5)
-        << Point(50, 35) << Point(75, 25) << Point(100, 5);
+    polyline_a << Point(0, 0) << Point(25, 75) << Point(50, 100)
+               << Point(75, 112.5) << Point(100, 110);
+    polyline_b << Point(0, 25) << Point(25, 55) << Point(50, 75)
+               << Point(75, 80) << Point(100, 75);
+    polyline_c << Point(0, 30) << Point(25, 37.5) << Point(50, 35)
+               << Point(75, 25) << Point(100, 5);
 
     // Add the polylines to the chart
     chart << polyline_a << polyline_b << polyline_c;
@@ -61,22 +62,40 @@ ShapeColl createSVGElements() {
 
     // Create and add another LineChart with Condensed notation
     elements << (LineChart(Dimensions(162.5, 12.5))
-        << (Polyline(Stroke(1.25, Color::Blue)) << Point(0, 0) << Point(25, 20) << Point(50, 32.5))
-        << (Polyline(Stroke(1.25, Color::Orange)) << Point(0, 25) << Point(25, 40) << Point(50, 50))
-        << (Polyline(Stroke(1.25, Color::Cyan)) << Point(0, 12.5) << Point(25, 32.5) << Point(50, 40)));
+                 << (Polyline(Stroke(1.25, Color::Blue))
+                     << Point(0, 0) << Point(25, 20) << Point(50, 32.5))
+                 << (Polyline(Stroke(1.25, Color::Orange))
+                     << Point(0, 25) << Point(25, 40) << Point(50, 50))
+                 << (Polyline(Stroke(1.25, Color::Cyan))
+                     << Point(0, 12.5) << Point(25, 32.5) << Point(50, 40)));
 
     // Create and add a Circle with specific properties
-    elements << Circle(Point(200, 200), 50, Fill(Color(100, 200, 120)), Stroke(2.5, Color(200, 250, 150)));
+    elements << Circle(Point(200, 200), 50, Fill(Color(100, 200, 120)),
+                       Stroke(2.5, Color(200, 250, 150)));
 
     // Create and add a Text element with specific properties
-    elements << Text(Point(12.5, 192.5), "Simple SVG", Fill(Color::Silver), Font(25, "Verdana"));
+    auto text = Text(Point(12.5, 192.5), "Simple SVG", Fill(Color::Silver),
+                     Font(25, "Verdana"));
+    elements << text;
+
+    // Create and add a Rectangle to represent the Text bounding box
+    auto bb = text.getBoundingBox();
+    elements << Rectangle(bb.origin, bb.size.width, bb.size.height,
+                          Fill(Color::Transparent), Stroke(1, Color::Red));
 
     // Create and add a Polygon with specific properties
-    elements << (Polygon(Fill(Color(200, 160, 220)), Stroke(1.25, Color(150, 160, 200))) << Point(50, 175)
-        << Point(62.5, 180) << Point(82.5, 175) << Point(87.5, 150) << Point(62.5, 137.5) << Point(45, 157.5));
+    elements << (Polygon(Fill(Color(200, 160, 220)),
+                         Stroke(1.25, Color(150, 160, 200)))
+                 << Point(50, 175) << Point(62.5, 180) << Point(82.5, 175)
+                 << Point(87.5, 150) << Point(62.5, 137.5) << Point(45, 157.5));
 
     // Create and add a Rectangle with specific properties
-    elements << Rectangle(Point(175, 137.5), 50, 37.5, Fill(Color::Yellow), Stroke(1, Color::Black));
+    elements << Rectangle(Point(175, 137.5), 50, 37.5, Fill(Color::Yellow),
+                          Stroke(1, Color::Black));
+
+    // Create an ellipse with specific properties
+    elements << Elipse(Point(200, 120), 50, 25, Fill(Color::Red),
+                       Stroke(1.5, Color::Black));
 
     // Return the collection of SVG elements
     return elements;
@@ -90,18 +109,18 @@ void demoDocLayout(const Layout &layout)
     std::string filename;
     switch (layout.origin)
     {
-    case Layout::TopLeft:
-        filename = "svg_topleft.svg";
-        break;
-    case Layout::TopRight:
-        filename = "svg_topright.svg";
-        break;
-    case Layout::BottomLeft:
-        filename = "svg_bottomleft.svg";
-        break;
-    case Layout::BottomRight:
-        filename = "svg_bottomright.svg";
-        break;
+        case Layout::TopLeft:
+            filename = "svg_topleft.svg";
+            break;
+        case Layout::TopRight:
+            filename = "svg_topright.svg";
+            break;
+        case Layout::BottomLeft:
+            filename = "svg_bottomleft.svg";
+            break;
+        case Layout::BottomRight:
+            filename = "svg_bottomright.svg";
+            break;
     }
 
     // Create SVG document with specified layout
@@ -116,7 +135,9 @@ void demoDocLayout(const Layout &layout)
 
     // Mark origin and the farthest point in the layout with circles
     doc << Circle(Point(0, 0), 20, Fill(Color::Red), Stroke(1, Color::Black));
-    doc << Circle(Point(layout.dimensions.width - 10, layout.dimensions.height - 10), 20, Fill(Color::Red), Stroke(1, Color::Black));
+    doc << Circle(
+        Point(layout.dimensions.width - 10, layout.dimensions.height - 10), 20,
+        Fill(Color::Red), Stroke(1, Color::Black));
 
     // Create and add all demo shapes
     ShapeColl elements = createSVGElements();
@@ -141,11 +162,9 @@ int main()
         Dimensions dimensions(500, 500);
 
         // Define array of all possible coordinate system origins
-        Layout::Origin layouts[] = {
-            Layout::TopLeft,
-            Layout::TopRight,
-            Layout::BottomLeft,
-            Layout::BottomRight};
+        const Layout::Origin layouts[] = {Layout::TopLeft, Layout::TopRight,
+                                          Layout::BottomLeft,
+                                          Layout::BottomRight};
 
         // Generate SVG file for each coordinate system origin
         for (Layout::Origin origin : layouts)

--- a/simple_svg_1.0.0.hpp
+++ b/simple_svg_1.0.0.hpp
@@ -32,750 +32,966 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef SIMPLE_SVG_HPP
 #define SIMPLE_SVG_HPP
 
-#include <vector>
-#include <string>
-#include <sstream>
 #include <fstream>
-
 #include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace svg
 {
-    // Utility XML/String Functions.
-    template <typename T>
-    inline std::string attribute(std::string const & attribute_name,
-        T const & value, std::string const & unit = "")
+// Utility XML/String Functions.
+template <typename T>
+inline std::string attribute(std::string const &attribute_name, T const &value,
+                             std::string const &unit = "")
+{
+    std::stringstream ss;
+    ss << attribute_name << "=\"" << value << unit << "\" ";
+    return ss.str();
+}
+inline std::string elemStart(std::string const &element_name)
+{
+    return "\t<" + element_name + " ";
+}
+inline std::string elemEnd(std::string const &element_name)
+{
+    return "</" + element_name + ">\n";
+}
+inline std::string emptyElemEnd() { return "/>\n"; }
+
+// Quick optional return type.  This allows functions to return an invalid
+//  value if no good return is possible.  The user checks for validity
+//  before using the returned value.
+template <typename T>
+class optional
+{
+   public:
+    explicit optional<T>(T const &type) : valid(true), type(type) {}
+    optional<T>() : valid(false), type(T()) {}
+    T *operator->()
     {
-        std::stringstream ss;
-        ss << attribute_name << "=\"" << value << unit << "\" ";
-        return ss.str();
+        // If we try to access an invalid value, an exception is thrown.
+        if (!valid) throw std::exception();
+
+        return &type;
     }
-    inline std::string elemStart(std::string const & element_name)
+    // Test for validity.
+    bool operator!() const { return !valid; }
+
+   private:
+    bool valid;
+    T type;
+};
+
+struct Dimensions
+{
+    Dimensions(double width, double height) : width(width), height(height) {}
+    explicit Dimensions(double combined = 0) : width(combined), height(combined)
     {
-        return "\t<" + element_name + " ";
     }
-    inline std::string elemEnd(std::string const & element_name)
+    double width;
+    double height;
+};
+
+struct Point
+{
+    explicit Point(double x = 0, double y = 0) : x(x), y(y) {}
+    double x;
+    double y;
+
+    Point operator+(const Point &other) const
     {
-        return "</" + element_name + ">\n";
-    }
-    inline std::string emptyElemEnd()
-    {
-        return "/>\n";
-    }
-
-    // Quick optional return type.  This allows functions to return an invalid
-    //  value if no good return is possible.  The user checks for validity
-    //  before using the returned value.
-    template <typename T>
-    class optional
-    {
-    public:
-        optional<T>(T const & type)
-            : valid(true), type(type) { }
-        optional<T>() : valid(false), type(T()) { }
-        T * operator->()
-        {
-            // If we try to access an invalid value, an exception is thrown.
-            if (!valid)
-                throw std::exception();
-
-            return &type;
-        }
-        // Test for validity.
-        bool operator!() const { return !valid; }
-    private:
-        bool valid;
-        T type;
-    };
-
-    struct Dimensions
-    {
-        Dimensions(double width, double height) : width(width), height(height) { }
-        explicit Dimensions(double combined = 0) : width(combined), height(combined) { }
-        double width;
-        double height;
-    };
-
-    struct Point
-    {
-        explicit Point(double x = 0, double y = 0) : x(x), y(y) {}
-        double x;
-        double y;
-
-        Point operator+(const Point& other) const {
-            return Point(x + other.x, y + other.y);
-        }
-
-        Point operator-(const Point &other) const
-        {
-            return Point(x - other.x, y - other.y);
-        }
-    };
-    inline optional<Point> getMinPoint(std::vector<Point> const & points)
-    {
-        if (points.empty())
-            return optional<Point>();
-
-        Point min = points[0];
-        for (unsigned i = 0; i < points.size(); ++i) {
-            if (points[i].x < min.x)
-                min.x = points[i].x;
-            if (points[i].y < min.y)
-                min.y = points[i].y;
-        }
-        return optional<Point>(min);
-    }
-    inline optional<Point> getMaxPoint(std::vector<Point> const & points)
-    {
-        if (points.empty())
-            return optional<Point>();
-
-        Point max = points[0];
-        for (unsigned i = 0; i < points.size(); ++i) {
-            if (points[i].x > max.x)
-                max.x = points[i].x;
-            if (points[i].y > max.y)
-                max.y = points[i].y;
-        }
-        return optional<Point>(max);
+        return Point(x + other.x, y + other.y);
     }
 
-    // Defines the dimensions, scale, origin, and origin offset of the document.
-    struct Layout
+    Point operator-(const Point &other) const
     {
-        enum Origin { TopLeft, BottomLeft, TopRight, BottomRight };
-
-        explicit Layout(Dimensions const &dimensions = Dimensions(400, 300), Origin origin = BottomLeft,
-                       double scale = 1, Point const &origin_offset = Point(0, 0))
-            : dimensions(dimensions), scale(scale), origin(origin), origin_offset(origin_offset) {}
-        Dimensions dimensions;
-        double scale;
-        Origin origin;
-        Point origin_offset;
-    };
-
-    // Convert coordinates in user space to SVG native space.
-    inline double translateX(double x, Layout const & layout)
-    {
-        if (layout.origin == Layout::BottomRight || layout.origin == Layout::TopRight)
-            return layout.dimensions.width - ((x + layout.origin_offset.x) * layout.scale);
-        else
-            return (layout.origin_offset.x + x) * layout.scale;
+        return Point(x - other.x, y - other.y);
     }
+};
+inline optional<Point> getMinPoint(std::vector<Point> const &points)
+{
+    if (points.empty()) return optional<Point>();
 
-    inline double translateY(double y, Layout const & layout)
+    Point min = points[0];
+    for (unsigned i = 0; i < points.size(); ++i)
     {
-        if (layout.origin == Layout::BottomLeft || layout.origin == Layout::BottomRight)
-            return layout.dimensions.height - ((y + layout.origin_offset.y) * layout.scale);
-        else
-            return (layout.origin_offset.y + y) * layout.scale;
+        if (points[i].x < min.x) min.x = points[i].x;
+        if (points[i].y < min.y) min.y = points[i].y;
     }
-    inline double translateScale(double dimension, Layout const & layout)
+    return optional<Point>(min);
+}
+inline optional<Point> getMaxPoint(std::vector<Point> const &points)
+{
+    if (points.empty()) return optional<Point>();
+
+    Point max = points[0];
+    for (unsigned i = 0; i < points.size(); ++i)
     {
-        return dimension * layout.scale;
+        if (points[i].x > max.x) max.x = points[i].x;
+        if (points[i].y > max.y) max.y = points[i].y;
     }
-
-    class Serializeable
-    {
-    public:
-        Serializeable() {}
-        virtual ~Serializeable() {};
-        virtual std::string toString(Layout const &layout) const = 0;
-    };
-
-    class Color : public Serializeable
-    {
-    public:
-        enum Defaults { Transparent = -1, Aqua, Black, Blue, Brown, Cyan, Fuchsia,
-            Green, Lime, Magenta, Orange, Purple, Red, Silver, White, Yellow };
-
-        Color(int r, int g, int b) : transparent(false), red(r), green(g), blue(b) { }
-        explicit Color(Defaults color)
-            : transparent(false), red(0), green(0), blue(0)
-        {
-            switch (color)
-            {
-                case Aqua: assign(0, 255, 255); break;
-                case Black: assign(0, 0, 0); break;
-                case Blue: assign(0, 0, 255); break;
-                case Brown: assign(165, 42, 42); break;
-                case Cyan: assign(0, 255, 255); break;
-                case Fuchsia: assign(255, 0, 255); break;
-                case Green: assign(0, 128, 0); break;
-                case Lime: assign(0, 255, 0); break;
-                case Magenta: assign(255, 0, 255); break;
-                case Orange: assign(255, 165, 0); break;
-                case Purple: assign(128, 0, 128); break;
-                case Red: assign(255, 0, 0); break;
-                case Silver: assign(192, 192, 192); break;
-                case White: assign(255, 255, 255); break;
-                case Yellow: assign(255, 255, 0); break;
-                default: transparent = true; break;
-            }
-        }
-        virtual ~Color() { }
-        std::string toString(Layout const &) const
-        {
-            std::stringstream ss;
-            if (transparent)
-                ss << "none";
-            else
-                ss << "rgb(" << red << "," << green << "," << blue << ")";
-            return ss.str();
-        }
-    private:
-            bool transparent;
-            int red;
-            int green;
-            int blue;
-
-            void assign(int r, int g, int b)
-            {
-                red = r;
-                green = g;
-                blue = b;
-            }
-    };
-
-    class Fill : public Serializeable
-    {
-    public:
-        Fill() : color(Color::Transparent) { }
-        explicit Fill(Color::Defaults color) : color(color) { }
-        explicit Fill(const Color& color) : color(color) { }
-
-        std::string toString(Layout const & layout) const
-        {
-            std::stringstream ss;
-            ss << attribute("fill", color.toString(layout));
-            return ss.str();
-        }
-    private:
-        Color color;
-    };
-
-    class Stroke : public Serializeable
-    {
-    public:
-        Stroke(double width = -1, Color::Defaults colorDefault = Color::Transparent, bool nonScalingStroke = false)
-            : width(width), color(Color(colorDefault)), nonScaling(nonScalingStroke) { }
-
-        Stroke(double width, const Color& color, bool nonScalingStroke = false)
-            : width(width), color(color), nonScaling(nonScalingStroke) { }
-
-        std::string toString(Layout const & layout) const
-        {
-            // If stroke width is invalid.
-            if (width < 0)
-                return std::string();
-
-            std::stringstream ss;
-            ss << attribute("stroke-width", translateScale(width, layout)) << attribute("stroke", color.toString(layout));
-            if (nonScaling)
-               ss << attribute("vector-effect", "non-scaling-stroke");
-            return ss.str();
-        }
-    private:
-        double width;
-        Color color;
-        bool nonScaling;
-    };
-
-    class Font : public Serializeable
-    {
-    public:
-        Font(double size = 12, std::string const & family = "Verdana") : size(size), family(family) { }
-        std::string toString(Layout const & layout) const
-        {
-            std::stringstream ss;
-            ss << attribute("font-size", translateScale(size, layout)) << attribute("font-family", family);
-            return ss.str();
-        }
-    private:
-        double size;
-        std::string family;
-    };
-
-    class Shape : public Serializeable
-    {
-    public:
-        Shape() : fill(Fill()), stroke(Stroke()) { }
-        Shape(const Fill& fill) : fill(fill), stroke(Stroke()) { }
-        Shape(const Stroke& stroke) : fill(Fill()), stroke(stroke) { }
-        Shape(const Fill& fill, const Stroke& stroke) : fill(fill), stroke(stroke) { }
-
-        virtual ~Shape() { }
-        virtual std::string toString(Layout const & layout) const = 0;
-        virtual void offset(Point const & offset) = 0;
-    protected:
-        Fill fill;
-        Stroke stroke;
-    };
-
-    class ShapeColl : public Shape
-    {
-    public:
-        ShapeColl() : Shape(Fill(), Stroke()) {}
-
-        template <typename T>
-        ShapeColl &operator<<(const T &serializeable)
-        {
-            static_assert(std::is_base_of<Serializeable, T>::value,
-                          "Must be derived from Serializeable");
-            elements.push_back(std::make_shared<T>(serializeable));
-            return *this;
-        }
-
-        std::string toString(Layout const &layout) const override
-        {
-            std::string ret;
-            for (const auto &element : elements)
-            {
-                ret += element->toString(layout);
-            }
-            return ret;
-        }
-
-        void offset(Point const &offset) override
-        {
-            for (const auto &element : elements)
-            {
-                if (Shape *shape = dynamic_cast<Shape *>(element.get()))
-                {
-                    shape->offset(offset);
-                }
-            }
-        }
-
-    private:
-        std::vector<std::shared_ptr<Serializeable>> elements;
-    };
-
-    template <typename T>
-    inline std::string vectorToString(std::vector<T> collection, Layout const & layout)
-    {
-        std::string combination_str;
-        for (unsigned i = 0; i < collection.size(); ++i)
-            combination_str += collection[i].toString(layout);
-
-        return combination_str;
-    }
-
-    class Circle : public Shape
-    {
-    public:
-        Circle(Point const &center, double diameter, Fill const &fill = Fill(),
-               Stroke const &stroke = Stroke())
-            : Shape(fill, stroke), center(center), radius(diameter / 2) {}
-        std::string toString(Layout const & layout) const
-        {
-            std::stringstream ss;
-            ss << elemStart("circle") << attribute("cx", translateX(center.x, layout))
-                << attribute("cy", translateY(center.y, layout))
-                << attribute("r", translateScale(radius, layout)) << fill.toString(layout)
-                << stroke.toString(layout) << emptyElemEnd();
-            return ss.str();
-        }
-        void offset(Point const & offset)
-        {
-            center.x += offset.x;
-            center.y += offset.y;
-        }
-    private:
-        Point center;
-        double radius;
-    };
-
-    class Elipse : public Shape
-    {
-    public:
-        Elipse(Point const & center, double width, double height,
-            Fill const & fill = Fill(), Stroke const & stroke = Stroke())
-            : Shape(fill, stroke), center(center), radius_width(width / 2),
-            radius_height(height / 2) { }
-        std::string toString(Layout const & layout) const
-        {
-            std::stringstream ss;
-            ss << elemStart("ellipse") << attribute("cx", translateX(center.x, layout))
-                << attribute("cy", translateY(center.y, layout))
-                << attribute("rx", translateScale(radius_width, layout))
-                << attribute("ry", translateScale(radius_height, layout))
-                << fill.toString(layout) << stroke.toString(layout) << emptyElemEnd();
-            return ss.str();
-        }
-        void offset(Point const & offset)
-        {
-            center.x += offset.x;
-            center.y += offset.y;
-        }
-    private:
-        Point center;
-        double radius_width;
-        double radius_height;
-    };
-
-    class Rectangle : public Shape
-    {
-    public:
-        Rectangle(Point const & edge, double width, double height,
-            Fill const & fill = Fill(), Stroke const & stroke = Stroke())
-            : Shape(fill, stroke), edge(edge), width(width),
-            height(height) { }
-        std::string toString(Layout const & layout) const
-        {
-            std::stringstream ss;
-            ss << elemStart("rect") << attribute("x", translateX(edge.x, layout))
-                << attribute("y", translateY(edge.y, layout))
-                << attribute("width", translateScale(width, layout))
-                << attribute("height", translateScale(height, layout))
-                << fill.toString(layout) << stroke.toString(layout) << emptyElemEnd();
-            return ss.str();
-        }
-        void offset(Point const & offset)
-        {
-            edge.x += offset.x;
-            edge.y += offset.y;
-        }
-    private:
-        Point edge;
-        double width;
-        double height;
-    };
-
-    class Line : public Shape
-    {
-    public:
-        Line(Point const & start_point, Point const & end_point,
-            Stroke const & stroke = Stroke())
-            : Shape(Fill(), stroke), start_point(start_point),
-            end_point(end_point) { }
-        std::string toString(Layout const & layout) const
-        {
-            std::stringstream ss;
-            ss << elemStart("line") << attribute("x1", translateX(start_point.x, layout))
-                << attribute("y1", translateY(start_point.y, layout))
-                << attribute("x2", translateX(end_point.x, layout))
-                << attribute("y2", translateY(end_point.y, layout))
-                << stroke.toString(layout) << emptyElemEnd();
-            return ss.str();
-        }
-        void offset(Point const & offset)
-        {
-            start_point.x += offset.x;
-            start_point.y += offset.y;
-
-            end_point.x += offset.x;
-            end_point.y += offset.y;
-        }
-    private:
-        Point start_point;
-        Point end_point;
-    };
-
-    class Polygon : public Shape
-    {
-    public:
-        Polygon(Fill const &fill = Fill(), Stroke const &stroke = Stroke())
-            : Shape(fill, stroke) {}
-        Polygon(Stroke const &stroke = Stroke())
-            : Shape(Fill(Color::Transparent), stroke) {}
-        Polygon & operator<<(Point const & point)
-        {
-            points.push_back(point);
-            return *this;
-        }
-        std::string toString(Layout const & layout) const
-        {
-            std::stringstream ss;
-            ss << elemStart("polygon");
-
-            ss << "points=\"";
-            for (unsigned i = 0; i < points.size(); ++i)
-                ss << translateX(points[i].x, layout) << "," << translateY(points[i].y, layout) << " ";
-            ss << "\" ";
-
-            ss << fill.toString(layout) << stroke.toString(layout) << emptyElemEnd();
-            return ss.str();
-        }
-        void offset(Point const & offset)
-        {
-            for (unsigned i = 0; i < points.size(); ++i) {
-                points[i].x += offset.x;
-                points[i].y += offset.y;
-            }
-        }
-    private:
-        std::vector<Point> points;
-    };
-
-    class Path : public Shape
-    {
-    public:
-        Path(Fill const &fill = Fill(), Stroke const &stroke = Stroke())
-            : Shape(fill, stroke)
-        {
-            startNewSubPath();
-        }
-
-        Path(Stroke const &stroke = Stroke())
-            : Shape(Fill(Color::Transparent), stroke)
-        {
-            startNewSubPath();
-        }
-       Path & operator<<(Point const & point)
-       {
-          paths.back().push_back(point);
-          return *this;
-       }
-
-       void startNewSubPath()
-       {
-          if (paths.empty() || 0 < paths.back().size())
-            paths.emplace_back();
-       }
-
-       std::string toString(Layout const & layout) const
-       {
-          std::stringstream ss;
-          ss << elemStart("path");
-
-          ss << "d=\"";
-          for (auto const& subpath: paths)
-          {
-             if (subpath.empty())
-                continue;
-
-             ss << "M";
-             for (auto const& point: subpath)
-                ss << translateX(point.x, layout) << "," << translateY(point.y, layout) << " ";
-             ss << "z ";
-          }
-          ss << "\" ";
-          ss << "fill-rule=\"evenodd\" ";
-
-          ss << fill.toString(layout) << stroke.toString(layout) << emptyElemEnd();
-          return ss.str();
-       }
-
-       void offset(Point const & offset)
-       {
-          for (auto& subpath : paths)
-             for (auto& point : subpath)
-             {
-                point.x += offset.x;
-                point.y += offset.y;
-             }
-       }
-    private:
-       std::vector<std::vector<Point>> paths;
-    };
-
-    class Polyline : public Shape
-    {
-    public:
-        Polyline(Fill const & fill = Fill(), Stroke const & stroke = Stroke())
-            : Shape(fill, stroke) { }
-
-        Polyline(Stroke const & stroke = Stroke())
-            : Shape(Fill(Color::Transparent), stroke) { }
-
-        Polyline(std::vector<Point> const & points,
-            Fill const & fill = Fill(), Stroke const & stroke = Stroke())
-            : Shape(fill, stroke), points(points) { }
-
-        Polyline & operator<<(Point const & point)
-        {
-            points.push_back(point);
-            return *this;
-        }
-        std::string toString(Layout const & layout) const
-        {
-            std::stringstream ss;
-            ss << elemStart("polyline");
-
-            ss << "points=\"";
-            for (unsigned i = 0; i < points.size(); ++i)
-                ss << translateX(points[i].x, layout) << "," << translateY(points[i].y, layout) << " ";
-            ss << "\" ";
-
-            ss << fill.toString(layout) << stroke.toString(layout) << emptyElemEnd();
-            return ss.str();
-        }
-        void offset(Point const & offset)
-        {
-            for (unsigned i = 0; i < points.size(); ++i) {
-                points[i].x += offset.x;
-                points[i].y += offset.y;
-            }
-        }
-        std::vector<Point> points;
-    };
-
-    class Text : public Shape
-    {
-    public:
-        Text(Point const & origin, std::string const & content, Fill const & fill = Fill(),
-             Font const & font = Font(), Stroke const & stroke = Stroke())
-            : Shape(fill, stroke), origin(origin), content(content), font(font) { }
-        std::string toString(Layout const & layout) const
-        {
-            std::stringstream ss;
-            ss << elemStart("text") << attribute("x", translateX(origin.x, layout))
-                << attribute("y", translateY(origin.y, layout))
-                << fill.toString(layout) << stroke.toString(layout) << font.toString(layout)
-                << ">" << content << elemEnd("text");
-            return ss.str();
-        }
-        void offset(Point const & offset)
-        {
-            origin.x += offset.x;
-            origin.y += offset.y;
-        }
-    private:
-        Point origin;
-        std::string content;
-        Font font;
-    };
-
-    // Sample charting class.
-    class LineChart : public Shape
-    {
-    public:
-        LineChart(Dimensions margin = Dimensions(), double scale = 1,
-                  Stroke const & axis_stroke = Stroke(.5, Color::Purple))
-            : axis_stroke(axis_stroke), margin(margin), scale(scale) { }
-        LineChart & operator<<(Polyline const & polyline)
-        {
-            if (polyline.points.empty())
-                return *this;
-
-            polylines.push_back(polyline);
-            return *this;
-        }
-        std::string toString(Layout const & layout) const
-        {
-            if (polylines.empty())
-                return "";
-
-            std::string ret;
-            for (unsigned i = 0; i < polylines.size(); ++i)
-                ret += polylineToString(polylines[i], layout);
-
-            return ret + axisString(layout);
-        }
-        void offset(Point const & offset)
-        {
-            for (unsigned i = 0; i < polylines.size(); ++i)
-                polylines[i].offset(offset);
-        }
-    private:
-        Stroke axis_stroke;
-        Dimensions margin;
-        double scale;
-        std::vector<Polyline> polylines;
-
-        optional<Dimensions> getDimensions() const
-        {
-            if (polylines.empty())
-                return optional<Dimensions>();
-
-            optional<Point> min = getMinPoint(polylines[0].points);
-            optional<Point> max = getMaxPoint(polylines[0].points);
-            for (unsigned i = 0; i < polylines.size(); ++i) {
-                if (getMinPoint(polylines[i].points)->x < min->x)
-                    min->x = getMinPoint(polylines[i].points)->x;
-                if (getMinPoint(polylines[i].points)->y < min->y)
-                    min->y = getMinPoint(polylines[i].points)->y;
-                if (getMaxPoint(polylines[i].points)->x > max->x)
-                    max->x = getMaxPoint(polylines[i].points)->x;
-                if (getMaxPoint(polylines[i].points)->y > max->y)
-                    max->y = getMaxPoint(polylines[i].points)->y;
-            }
-
-            return optional<Dimensions>(Dimensions(max->x - min->x, max->y - min->y));
-        }
-        std::string axisString(Layout const & layout) const
-        {
-            optional<Dimensions> dimensions = getDimensions();
-            if (!dimensions)
-                return "";
-
-            // Make the axis 10% wider and higher than the data points.
-            double width = dimensions->width * 1.1;
-            double height = dimensions->height * 1.1;
-
-            // Draw the axis.
-            Polyline axis(Fill(Color::Transparent), axis_stroke);
-            axis << Point(margin.width, margin.height + height) << Point(margin.width, margin.height)
-                 << Point(margin.width + width, margin.height);
-
-            return axis.toString(layout);
-        }
-        std::string polylineToString(Polyline const & polyline, Layout const & layout) const
-        {
-            Polyline shifted_polyline = polyline;
-            shifted_polyline.offset(Point(margin.width, margin.height));
-
-            std::vector<Circle> vertices;
-            for (unsigned i = 0; i < shifted_polyline.points.size(); ++i)
-                vertices.push_back(Circle(shifted_polyline.points[i],
-                                          getDimensions()->height / 30.0,
-                                          Fill(Color::Black)));  // Use Fill instead of direct Color
-
-            return shifted_polyline.toString(layout) + vectorToString(vertices, layout);
-        }
-    };
-
-    class Document
-    {
-    public:
-        Document() {};
-        Document(std::string const & file_name, Layout layout = Layout())
-            : file_name(file_name), layout(layout) { }
-
-        Document & operator<<(Shape const & shape)
-        {
-            body_nodes_str_list.push_back(shape.toString(layout));
-            return *this;
-        }
-        std::string toString() const
-        {
-            std::stringstream ss;
-            writeToStream(ss);
-            return ss.str();
-        }
-        bool save() const
-        {
-            std::ofstream ofs(file_name.c_str());
-            if (!ofs.good())
-                return false;
-
-            writeToStream(ofs);
-            ofs.close();
-            return true;
-        }
-    private:
-        void writeToStream(std::ostream& str) const
-        {
-            str << "<?xml " << attribute("version", "1.0") << attribute("standalone", "no")
-                << "?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" "
-                << "\"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<svg "
-                << attribute("width", layout.dimensions.width, "px")
-                << attribute("height", layout.dimensions.height, "px")
-                << attribute("xmlns", "http://www.w3.org/2000/svg")
-                << attribute("version", "1.1") << ">\n";
-            for (const auto& body_node_str : body_nodes_str_list) {
-                str << body_node_str;
-            }
-            str << elemEnd("svg");
-        }
-
-    private:
-        std::string file_name;
-        Layout layout;
-
-        std::vector<std::string> body_nodes_str_list;
-    };
+    return optional<Point>(max);
 }
 
+struct Size
+{
+    Size(double width = 0, double height = 0) : width(width), height(height) {}
+    double width;
+    double height;
+};
+
+inline Point operator+(Point const &p, Size const &s)
+{
+    return Point(p.x + s.width, p.y + s.height);
+}
+
+struct Box
+{
+    Box(Point const &origin, Size const &size) : origin(origin), size(size) {}
+    Point origin;
+    Size size;
+};
+
+// Defines the dimensions, scale, origin, and origin offset of the document.
+struct Layout
+{
+    enum Origin
+    {
+        TopLeft,
+        BottomLeft,
+        TopRight,
+        BottomRight
+    };
+
+    explicit Layout(Dimensions const &dimensions = Dimensions(400, 300),
+                    Origin origin = BottomLeft, double scale = 1,
+                    Point const &origin_offset = Point(0, 0))
+        : dimensions(dimensions),
+          scale(scale),
+          origin(origin),
+          origin_offset(origin_offset)
+    {
+    }
+    Dimensions dimensions;
+    double scale;
+    Origin origin;
+    Point origin_offset;
+};
+
+// Convert coordinates in user space to SVG native space.
+inline double translateX(double x, Layout const &layout)
+{
+    if (layout.origin == Layout::BottomRight ||
+        layout.origin == Layout::TopRight)
+        return layout.dimensions.width -
+               ((x + layout.origin_offset.x) * layout.scale);
+    else
+        return (layout.origin_offset.x + x) * layout.scale;
+}
+
+inline double translateY(double y, Layout const &layout)
+{
+    if (layout.origin == Layout::BottomLeft ||
+        layout.origin == Layout::BottomRight)
+        return layout.dimensions.height -
+               ((y + layout.origin_offset.y) * layout.scale);
+    else
+        return (layout.origin_offset.y + y) * layout.scale;
+}
+inline double translateScale(double dimension, Layout const &layout)
+{
+    return dimension * layout.scale;
+}
+
+class Serializeable
+{
+   public:
+    Serializeable() {}
+    virtual ~Serializeable() {};
+    virtual std::string toString(Layout const &layout) const = 0;
+};
+
+class Color : public Serializeable
+{
+   public:
+    enum Defaults
+    {
+        Transparent = -1,
+        Aqua,
+        Black,
+        Blue,
+        Brown,
+        Cyan,
+        Fuchsia,
+        Green,
+        Lime,
+        Magenta,
+        Orange,
+        Purple,
+        Red,
+        Silver,
+        White,
+        Yellow
+    };
+
+    Color(int r, int g, int b) : transparent(false), red(r), green(g), blue(b)
+    {
+    }
+    explicit Color(Defaults color)
+        : transparent(false), red(0), green(0), blue(0)
+    {
+        switch (color)
+        {
+            case Aqua:
+                assign(0, 255, 255);
+                break;
+            case Black:
+                assign(0, 0, 0);
+                break;
+            case Blue:
+                assign(0, 0, 255);
+                break;
+            case Brown:
+                assign(165, 42, 42);
+                break;
+            case Cyan:
+                assign(0, 255, 255);
+                break;
+            case Fuchsia:
+                assign(255, 0, 255);
+                break;
+            case Green:
+                assign(0, 128, 0);
+                break;
+            case Lime:
+                assign(0, 255, 0);
+                break;
+            case Magenta:
+                assign(255, 0, 255);
+                break;
+            case Orange:
+                assign(255, 165, 0);
+                break;
+            case Purple:
+                assign(128, 0, 128);
+                break;
+            case Red:
+                assign(255, 0, 0);
+                break;
+            case Silver:
+                assign(192, 192, 192);
+                break;
+            case White:
+                assign(255, 255, 255);
+                break;
+            case Yellow:
+                assign(255, 255, 0);
+                break;
+            default:
+                transparent = true;
+                break;
+        }
+    }
+    virtual ~Color() override {}
+    std::string toString(Layout const &) const override
+    {
+        std::stringstream ss;
+        if (transparent)
+            ss << "none";
+        else
+            ss << "rgb(" << red << "," << green << "," << blue << ")";
+        return ss.str();
+    }
+
+   private:
+    bool transparent;
+    int red;
+    int green;
+    int blue;
+
+    void assign(int r, int g, int b)
+    {
+        red = r;
+        green = g;
+        blue = b;
+    }
+};
+
+class Fill : public Serializeable
+{
+   public:
+    Fill() : color(Color::Transparent) {}
+    explicit Fill(Color::Defaults color) : color(color) {}
+    explicit Fill(const Color &color) : color(color) {}
+
+    std::string toString(Layout const &layout) const override
+    {
+        std::stringstream ss;
+        ss << attribute("fill", color.toString(layout));
+        return ss.str();
+    }
+
+   private:
+    Color color;
+};
+
+class Stroke : public Serializeable
+{
+   public:
+    explicit Stroke(double width = -1,
+                    Color::Defaults colorDefault = Color::Transparent,
+                    bool nonScalingStroke = false)
+        : width(width), color(Color(colorDefault)), nonScaling(nonScalingStroke)
+    {
+    }
+
+    Stroke(double width, const Color &color, bool nonScalingStroke = false)
+        : width(width), color(color), nonScaling(nonScalingStroke)
+    {
+    }
+
+    std::string toString(Layout const &layout) const override
+    {
+        // If stroke width is invalid.
+        if (width < 0) return std::string();
+
+        std::stringstream ss;
+        ss << attribute("stroke-width", translateScale(width, layout))
+           << attribute("stroke", color.toString(layout));
+        if (nonScaling) ss << attribute("vector-effect", "non-scaling-stroke");
+        return ss.str();
+    }
+
+   private:
+    double width;
+    Color color;
+    bool nonScaling;
+};
+
+class Font : public Serializeable
+{
+   public:
+    explicit Font(double size = 12, std::string const &family = "Verdana")
+        : size(size), family(family)
+    {
+    }
+    std::string toString(Layout const &layout) const override
+    {
+        std::stringstream ss;
+        ss << attribute("font-size", translateScale(size, layout))
+           << attribute("font-family", family);
+        return ss.str();
+    }
+
+    double getSize() const { return size; }
+
+   private:
+    double size;
+    std::string family;
+};
+
+class Shape : public Serializeable
+{
+   public:
+    Shape() : fill(Fill()), stroke(Stroke()) {}
+    Shape(const Fill &fill) : fill(fill), stroke(Stroke()) {}
+    Shape(const Stroke &stroke) : fill(Fill()), stroke(stroke) {}
+    Shape(const Fill &fill, const Stroke &stroke) : fill(fill), stroke(stroke)
+    {
+    }
+
+    virtual ~Shape() override {}
+    virtual std::string toString(Layout const &layout) const override = 0;
+    virtual void offset(Point const &offset) = 0;
+
+   protected:
+    Fill fill;
+    Stroke stroke;
+};
+
+class ShapeColl : public Shape
+{
+   public:
+    ShapeColl() : Shape(Fill(), Stroke()) {}
+
+    template <typename T>
+    ShapeColl &operator<<(const T &serializeable)
+    {
+        static_assert(std::is_base_of<Serializeable, T>::value,
+                      "Must be derived from Serializeable");
+        elements.push_back(std::make_shared<T>(serializeable));
+        return *this;
+    }
+
+    std::string toString(Layout const &layout) const override
+    {
+        std::string ret;
+        for (const auto &element : elements)
+        {
+            ret += element->toString(layout);
+        }
+        return ret;
+    }
+
+    void offset(Point const &offset) override
+    {
+        for (const auto &element : elements)
+        {
+            if (Shape *shape = dynamic_cast<Shape *>(element.get()))
+            {
+                shape->offset(offset);
+            }
+        }
+    }
+
+   private:
+    std::vector<std::shared_ptr<Serializeable>> elements;
+};
+
+template <typename T>
+inline std::string vectorToString(std::vector<T> collection,
+                                  Layout const &layout)
+{
+    std::string combination_str;
+    for (unsigned i = 0; i < collection.size(); ++i)
+        combination_str += collection[i].toString(layout);
+
+    return combination_str;
+}
+
+class Circle : public Shape
+{
+   public:
+    Circle(Point const &center, double diameter, Fill const &fill = Fill(),
+           Stroke const &stroke = Stroke())
+        : Shape(fill, stroke), center(center), radius(diameter / 2)
+    {
+    }
+    std::string toString(Layout const &layout) const override
+    {
+        std::stringstream ss;
+        ss << elemStart("circle")
+           << attribute("cx", translateX(center.x, layout))
+           << attribute("cy", translateY(center.y, layout))
+           << attribute("r", translateScale(radius, layout))
+           << fill.toString(layout) << stroke.toString(layout)
+           << emptyElemEnd();
+        return ss.str();
+    }
+    void offset(Point const &offset) override
+    {
+        center.x += offset.x;
+        center.y += offset.y;
+    }
+
+   private:
+    Point center;
+    double radius;
+};
+
+class Elipse : public Shape
+{
+   public:
+    Elipse(Point const &center, double width, double height,
+           Fill const &fill = Fill(), Stroke const &stroke = Stroke())
+        : Shape(fill, stroke),
+          center(center),
+          radius_width(width / 2),
+          radius_height(height / 2)
+    {
+    }
+    std::string toString(Layout const &layout) const override
+    {
+        std::stringstream ss;
+        ss << elemStart("ellipse")
+           << attribute("cx", translateX(center.x, layout))
+           << attribute("cy", translateY(center.y, layout))
+           << attribute("rx", translateScale(radius_width, layout))
+           << attribute("ry", translateScale(radius_height, layout))
+           << fill.toString(layout) << stroke.toString(layout)
+           << emptyElemEnd();
+        return ss.str();
+    }
+    void offset(Point const &offset) override
+    {
+        center.x += offset.x;
+        center.y += offset.y;
+    }
+
+   private:
+    Point center;
+    double radius_width;
+    double radius_height;
+};
+
+class Rectangle : public Shape
+{
+   public:
+    Rectangle(Point const &edge, double width, double height,
+              Fill const &fill = Fill(), Stroke const &stroke = Stroke())
+        : Shape(fill, stroke), edge(edge), width(width), height(height)
+    {
+    }
+    std::string toString(Layout const &layout) const override
+    {
+        std::stringstream ss;
+        double x = translateX(edge.x, layout);
+        double y = translateY(edge.y, layout);
+        double w = translateScale(width, layout);
+        double h = translateScale(height, layout);
+
+        // Adjust y-coordinate for top vs. bottom origin
+        if (layout.origin == Layout::TopLeft ||
+            layout.origin == Layout::TopRight)
+        {
+            // No change needed for y
+        }
+        else
+        {
+            y -= h;
+        }
+
+        // Adjust x-coordinate for left vs. right origin
+        if (layout.origin == Layout::TopLeft ||
+            layout.origin == Layout::BottomLeft)
+        {
+            // No change needed for x
+        }
+        else
+        {
+            x -= w;
+        }
+
+        ss << elemStart("rect") << attribute("x", x) << attribute("y", y)
+           << attribute("width", w) << attribute("height", h)
+           << fill.toString(layout) << stroke.toString(layout)
+           << emptyElemEnd();
+        return ss.str();
+    }
+    void offset(Point const &offset) override
+    {
+        edge.x += offset.x;
+        edge.y += offset.y;
+    }
+
+   private:
+    Point edge;
+    double width;
+    double height;
+};
+
+class Line : public Shape
+{
+   public:
+    Line(Point const &start_point, Point const &end_point,
+         Stroke const &stroke = Stroke())
+        : Shape(Fill(), stroke), start_point(start_point), end_point(end_point)
+    {
+    }
+    std::string toString(Layout const &layout) const override
+    {
+        std::stringstream ss;
+        ss << elemStart("line")
+           << attribute("x1", translateX(start_point.x, layout))
+           << attribute("y1", translateY(start_point.y, layout))
+           << attribute("x2", translateX(end_point.x, layout))
+           << attribute("y2", translateY(end_point.y, layout))
+           << stroke.toString(layout) << emptyElemEnd();
+        return ss.str();
+    }
+    void offset(Point const &offset) override
+    {
+        start_point.x += offset.x;
+        start_point.y += offset.y;
+
+        end_point.x += offset.x;
+        end_point.y += offset.y;
+    }
+
+   private:
+    Point start_point;
+    Point end_point;
+};
+
+class Polygon : public Shape
+{
+   public:
+    explicit Polygon(Fill const &fill = Fill(), Stroke const &stroke = Stroke())
+        : Shape(fill, stroke)
+    {
+    }
+
+    explicit Polygon(Stroke const &stroke = Stroke())
+        : Shape(Fill(Color::Transparent), stroke)
+    {
+    }
+    Polygon &operator<<(Point const &point)
+    {
+        points.push_back(point);
+        return *this;
+    }
+    std::string toString(Layout const &layout) const override
+    {
+        std::stringstream ss;
+        ss << elemStart("polygon");
+
+        ss << "points=\"";
+        for (unsigned i = 0; i < points.size(); ++i)
+            ss << translateX(points[i].x, layout) << ","
+               << translateY(points[i].y, layout) << " ";
+        ss << "\" ";
+
+        ss << fill.toString(layout) << stroke.toString(layout)
+           << emptyElemEnd();
+        return ss.str();
+    }
+    void offset(Point const &offset) override
+    {
+        for (unsigned i = 0; i < points.size(); ++i)
+        {
+            points[i].x += offset.x;
+            points[i].y += offset.y;
+        }
+    }
+
+   private:
+    std::vector<Point> points;
+};
+
+class Path : public Shape
+{
+   public:
+    explicit Path(Fill const &fill = Fill(), Stroke const &stroke = Stroke())
+        : Shape(fill, stroke)
+    {
+        startNewSubPath();
+    }
+
+    explicit Path(Stroke const &stroke = Stroke())
+        : Shape(Fill(Color::Transparent), stroke)
+    {
+        startNewSubPath();
+    }
+    Path &operator<<(Point const &point)
+    {
+        paths.back().push_back(point);
+        return *this;
+    }
+
+    void startNewSubPath()
+    {
+        if (paths.empty() || 0 < paths.back().size()) paths.emplace_back();
+    }
+
+    std::string toString(Layout const &layout) const override
+    {
+        std::stringstream ss;
+        ss << elemStart("path");
+
+        ss << "d=\"";
+        for (auto const &subpath : paths)
+        {
+            if (subpath.empty()) continue;
+
+            ss << "M";
+            for (auto const &point : subpath)
+                ss << translateX(point.x, layout) << ","
+                   << translateY(point.y, layout) << " ";
+            ss << "z ";
+        }
+        ss << "\" ";
+        ss << "fill-rule=\"evenodd\" ";
+
+        ss << fill.toString(layout) << stroke.toString(layout)
+           << emptyElemEnd();
+        return ss.str();
+    }
+
+    void offset(Point const &offset) override
+    {
+        for (auto &subpath : paths)
+            for (auto &point : subpath)
+            {
+                point.x += offset.x;
+                point.y += offset.y;
+            }
+    }
+
+   private:
+    std::vector<std::vector<Point>> paths;
+};
+
+class Polyline : public Shape
+{
+   public:
+    explicit Polyline(Fill const &fill = Fill(),
+                      Stroke const &stroke = Stroke())
+        : Shape(fill, stroke)
+    {
+    }
+
+    explicit Polyline(Stroke const &stroke = Stroke())
+        : Shape(Fill(Color::Transparent), stroke)
+    {
+    }
+
+    explicit Polyline(std::vector<Point> const &points,
+                      Fill const &fill = Fill(),
+                      Stroke const &stroke = Stroke())
+        : Shape(fill, stroke), points(points)
+    {
+    }
+
+    Polyline &operator<<(Point const &point)
+    {
+        points.push_back(point);
+        return *this;
+    }
+    std::string toString(Layout const &layout) const override
+    {
+        std::stringstream ss;
+        ss << elemStart("polyline");
+
+        ss << "points=\"";
+        for (unsigned i = 0; i < points.size(); ++i)
+            ss << translateX(points[i].x, layout) << ","
+               << translateY(points[i].y, layout) << " ";
+        ss << "\" ";
+
+        ss << fill.toString(layout) << stroke.toString(layout)
+           << emptyElemEnd();
+        return ss.str();
+    }
+    void offset(Point const &offset) override
+    {
+        for (unsigned i = 0; i < points.size(); ++i)
+        {
+            points[i].x += offset.x;
+            points[i].y += offset.y;
+        }
+    }
+    std::vector<Point> points;
+};
+
+class Text : public Shape
+{
+   public:
+    Text(Point const &origin, std::string const &content,
+         Fill const &fill = Fill(), Font const &font = Font(),
+         Stroke const &stroke = Stroke())
+        : Shape(fill, stroke), origin(origin), content(content), font(font)
+    {
+    }
+    std::string toString(Layout const &layout) const override
+    {
+        std::stringstream ss;
+        Box bbox = getBoundingBox();
+        double x = translateX(origin.x, layout);
+        double y = translateY(origin.y, layout);
+
+        // Adjust position based on layout origin
+        switch (layout.origin)
+        {
+            case Layout::TopLeft:
+                y += bbox.size.height;
+                break;
+            case Layout::TopRight:
+                x -= bbox.size.width;
+                y += bbox.size.height;
+                break;
+            case Layout::BottomRight:
+                x -= bbox.size.width;
+                break;
+            case Layout::BottomLeft:
+                // No adjustment needed
+                break;
+        }
+
+        ss << elemStart("text") << attribute("x", x) << attribute("y", y)
+           << fill.toString(layout) << stroke.toString(layout)
+           << font.toString(layout) << ">" << content << elemEnd("text");
+        return ss.str();
+    }
+    void offset(Point const &offset) override
+    {
+        origin.x += offset.x;
+        origin.y += offset.y;
+    }
+
+    // Get the bounding box of the text
+    Box getBoundingBox() const
+    {
+        double width = measureTextWidth(content, font);
+        double height = measureTextHeight(font);
+        return Box(origin, Size(width, height));
+    }
+
+   private:
+    Point origin;
+    std::string content;
+    Font font;
+
+    double measureTextWidth(std::string const &text, Font const &font) const
+    {
+        // Implement text width measurement based on font
+        return text.length() * font.getSize() / 1.5;  // approximation
+    }
+
+    double measureTextHeight(Font const &font) const
+    {
+        // Implement text height measurement based on font
+        return font.getSize();  // approximation
+    }
+};
+
+// Sample charting class.
+class LineChart : public Shape
+{
+   public:
+    explicit LineChart(Dimensions margin = Dimensions(), double scale = 1,
+                       Stroke const &axis_stroke = Stroke(.5, Color::Purple))
+        : axis_stroke(axis_stroke), margin(margin), scale(scale)
+    {
+    }
+    LineChart &operator<<(Polyline const &polyline)
+    {
+        if (polyline.points.empty()) return *this;
+
+        polylines.push_back(polyline);
+        return *this;
+    }
+    std::string toString(Layout const &layout) const override
+    {
+        if (polylines.empty()) return "";
+
+        std::string ret;
+        for (unsigned i = 0; i < polylines.size(); ++i)
+            ret += polylineToString(polylines[i], layout);
+
+        return ret + axisString(layout);
+    }
+    void offset(Point const &offset) override
+    {
+        for (unsigned i = 0; i < polylines.size(); ++i)
+            polylines[i].offset(offset);
+    }
+
+   private:
+    Stroke axis_stroke;
+    Dimensions margin;
+    double scale;
+    std::vector<Polyline> polylines;
+
+    optional<Dimensions> getDimensions() const
+    {
+        if (polylines.empty()) return optional<Dimensions>();
+
+        optional<Point> min = getMinPoint(polylines[0].points);
+        optional<Point> max = getMaxPoint(polylines[0].points);
+        for (unsigned i = 0; i < polylines.size(); ++i)
+        {
+            if (getMinPoint(polylines[i].points)->x < min->x)
+                min->x = getMinPoint(polylines[i].points)->x;
+            if (getMinPoint(polylines[i].points)->y < min->y)
+                min->y = getMinPoint(polylines[i].points)->y;
+            if (getMaxPoint(polylines[i].points)->x > max->x)
+                max->x = getMaxPoint(polylines[i].points)->x;
+            if (getMaxPoint(polylines[i].points)->y > max->y)
+                max->y = getMaxPoint(polylines[i].points)->y;
+        }
+
+        return optional<Dimensions>(
+            Dimensions(max->x - min->x, max->y - min->y));
+    }
+    std::string axisString(Layout const &layout) const
+    {
+        optional<Dimensions> dimensions = getDimensions();
+        if (!dimensions) return "";
+
+        // Make the axis 10% wider and higher than the data points.
+        double width = dimensions->width * 1.1;
+        double height = dimensions->height * 1.1;
+
+        // Draw the axis.
+        Polyline axis(Fill(Color::Transparent), axis_stroke);
+        axis << Point(margin.width, margin.height + height)
+             << Point(margin.width, margin.height)
+             << Point(margin.width + width, margin.height);
+
+        return axis.toString(layout);
+    }
+    std::string polylineToString(Polyline const &polyline,
+                                 Layout const &layout) const
+    {
+        Polyline shifted_polyline = polyline;
+        shifted_polyline.offset(Point(margin.width, margin.height));
+
+        std::vector<Circle> vertices;
+        for (unsigned i = 0; i < shifted_polyline.points.size(); ++i)
+            vertices.push_back(Circle(
+                shifted_polyline.points[i], getDimensions()->height / 30.0,
+                Fill(Color::Black)));  // Use Fill instead of direct Color
+
+        return shifted_polyline.toString(layout) +
+               vectorToString(vertices, layout);
+    }
+};
+
+class Document
+{
+   public:
+    Document() {};
+    explicit Document(std::string const &file_name,
+                      Layout const &layout = Layout())
+        : file_name(file_name), layout(layout)
+    {
+    }
+
+    Document &operator<<(Shape const &shape)
+    {
+        body_nodes_str_list.push_back(shape.toString(layout));
+        return *this;
+    }
+    std::string toString() const
+    {
+        std::stringstream ss;
+        writeToStream(ss);
+        return ss.str();
+    }
+    bool save() const
+    {
+        std::ofstream ofs(file_name.c_str());
+        if (!ofs.good()) return false;
+
+        writeToStream(ofs);
+        ofs.close();
+        return true;
+    }
+
+   private:
+    void writeToStream(std::ostream &str) const
+    {
+        str << "<?xml " << attribute("version", "1.0")
+            << attribute("standalone", "no")
+            << "?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" "
+            << "\"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<svg "
+            << attribute("width", layout.dimensions.width, "px")
+            << attribute("height", layout.dimensions.height, "px")
+            << attribute("xmlns", "http://www.w3.org/2000/svg")
+            << attribute("version", "1.1") << ">\n";
+        for (const auto &body_node_str : body_nodes_str_list)
+        {
+            str << body_node_str;
+        }
+        str << elemEnd("svg");
+    }
+
+   private:
+    std::string file_name;
+    Layout layout;
+
+    std::vector<std::string> body_nodes_str_list;
+};
+}  // namespace svg
 #endif

--- a/tests/simple_svg_test.cpp
+++ b/tests/simple_svg_test.cpp
@@ -5,29 +5,34 @@
 
 // TEST_F
 // TEST_F is used to define a test case that uses a test fixture.
-// A test fixture is a class derived from ::testing::Test that provides common setup and teardown code for multiple tests.
-// It is suitable for tests that need to share common setup, state, or helper functions.
+// A test fixture is a class derived from ::testing::Test that provides common
+// setup and teardown code for multiple tests. It is suitable for tests that
+// need to share common setup, state, or helper functions.
 
 #include <gtest/gtest.h>
-#include "../simple_svg_1.0.0.hpp"
+
 #include <sstream>
+
+#include "../simple_svg_1.0.0.hpp"
 
 using namespace svg;
 
-// SVGTest -----------------------------------------------------------------------------------------
+// SVGTest
+// -----------------------------------------------------------------------------------------
 
 class SVGTest : public ::testing::Test
 {
-protected:
+   protected:
     Layout layout;
 
     void SetUp() override
     {
-        layout = Layout(Dimensions(100, 100), Layout::TopLeft);
+        layout = Layout(Dimensions(100, 100),
+                        Layout::TopLeft);  // default is BottomLeft
     }
 };
 
-TEST_F(SVGTest,  ShapeCollTest)
+TEST_F(SVGTest, ShapeCollTest)
 {
     ShapeColl ShapeColl;
     std::string sercollStr = ShapeColl.toString(layout);
@@ -35,9 +40,12 @@ TEST_F(SVGTest,  ShapeCollTest)
     // std::cout << "* ShapeCollTest sercollStr: " << sercollStr << std::endl;
     EXPECT_TRUE(sercollStr.empty());
 
-    ShapeColl << Text(Point(10, 20), "Hello, SVG!", Fill(Color::Black), Font(12, "Arial"));
+    ShapeColl << Text(Point(10, 20), "Hello, SVG!", Fill(Color::Black),
+                      Font(12, "Arial"));
 
-    std::string expectedStr = "\t<text x=\"10\" y=\"20\" fill=\"rgb(0,0,0)\" font-size=\"12\" font-family=\"Arial\" >Hello, SVG!</text>\n";
+    std::string expectedStr =
+        "\t<text x=\"10\" y=\"32\" fill=\"rgb(0,0,0)\" font-size=\"12\" "
+        "font-family=\"Arial\" >Hello, SVG!</text>\n";
     sercollStr = ShapeColl.toString(layout);
     // std::cout << "* ShapeCollTest sercollStr: " << sercollStr << std::endl;
     EXPECT_EQ(sercollStr, expectedStr);
@@ -62,17 +70,22 @@ TEST_F(SVGTest, PolygonTest)
     Polygon polygon(Fill(Color::Green), Stroke(1, Color::Black));
     polygon << Point(0, 0) << Point(100, 0) << Point(100, 100) << Point(0, 100);
     std::string polygonStr = polygon.toString(layout);
-    EXPECT_TRUE(polygonStr.find("points=\"0,0 100,0 100,100 0,100 \"") != std::string::npos);
+    EXPECT_TRUE(polygonStr.find("points=\"0,0 100,0 100,100 0,100 \"") !=
+                std::string::npos);
     EXPECT_TRUE(polygonStr.find("fill=\"rgb(0,128,0)\"") != std::string::npos);
     EXPECT_TRUE(polygonStr.find("stroke=\"rgb(0,0,0)\"") != std::string::npos);
 }
 
 TEST_F(SVGTest, TextTest)
 {
-    Text text(Point(10, 20), "Hello SVG", Fill(Color::Black), Font(12, "Arial"));
+    Text text(Point(10, 20), "Hello SVG", Fill(Color::Black),
+              Font(12, "Arial"));
     std::string textStr = text.toString(layout);
+
+    // std::cout << "TextTest textStr:\n" << textStr << std::endl;
+
     EXPECT_TRUE(textStr.find("x=\"10\"") != std::string::npos);
-    EXPECT_TRUE(textStr.find("y=\"20\"") != std::string::npos);
+    EXPECT_TRUE(textStr.find("y=\"32\"") != std::string::npos);
     EXPECT_TRUE(textStr.find("font-size=\"12\"") != std::string::npos);
     EXPECT_TRUE(textStr.find("font-family=\"Arial\"") != std::string::npos);
     EXPECT_TRUE(textStr.find(">Hello SVG<") != std::string::npos);
@@ -92,8 +105,10 @@ TEST_F(SVGTest, LineChartTest)
     std::string chartStr = chart.toString(layout);
     EXPECT_TRUE(chartStr.find("stroke=\"rgb(0,0,255)\"") != std::string::npos);
     EXPECT_TRUE(chartStr.find("stroke=\"rgb(255,0,0)\"") != std::string::npos);
-    EXPECT_TRUE(chartStr.find("points=\"0,0 10,10 20,20 \"") != std::string::npos);
-    EXPECT_TRUE(chartStr.find("points=\"0,20 10,10 20,0 \"") != std::string::npos);
+    EXPECT_TRUE(chartStr.find("points=\"0,0 10,10 20,20 \"") !=
+                std::string::npos);
+    EXPECT_TRUE(chartStr.find("points=\"0,20 10,10 20,0 \"") !=
+                std::string::npos);
 }
 
 TEST_F(SVGTest, DocumentTest)
@@ -107,9 +122,12 @@ TEST_F(SVGTest, DocumentTest)
     // std::cout << "DocumentTest SVG:\n"
     //           << docStr << std::endl;
 
-    EXPECT_TRUE(docStr.find("<svg width=\"200px\" height=\"200px\"") != std::string::npos);
-    EXPECT_TRUE(docStr.find("<circle cx=\"100\" cy=\"100\" r=\"25\"") != std::string::npos);
-    EXPECT_TRUE(docStr.find("<text x=\"10\" y=\"180\" fill=\"rgb(0,0,0)\"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("<svg width=\"200px\" height=\"200px\"") !=
+                std::string::npos);
+    EXPECT_TRUE(docStr.find("<circle cx=\"100\" cy=\"100\" r=\"25\"") !=
+                std::string::npos);
+    EXPECT_TRUE(docStr.find("<text x=\"10\" y=\"180\" fill=\"rgb(0,0,0)\"") !=
+                std::string::npos);
 }
 
 TEST_F(SVGTest, PathTest)
@@ -126,7 +144,8 @@ TEST_F(SVGTest, PathTest)
     //           << docStr << std::endl;
 
     EXPECT_TRUE(docStr.find("<path") != std::string::npos);
-    EXPECT_TRUE(docStr.find("d=\"M0,300 100,300 100,200 z M0,200 0,300 z \"") != std::string::npos);
+    EXPECT_TRUE(docStr.find("d=\"M0,300 100,300 100,200 z M0,200 0,300 z \"") !=
+                std::string::npos);
     EXPECT_TRUE(docStr.find("fill=\"rgb(255,255,0)\"") != std::string::npos);
     EXPECT_TRUE(docStr.find("stroke=\"rgb(128,0,128)\"") != std::string::npos);
     EXPECT_TRUE(docStr.find("stroke-width=\"2\"") != std::string::npos);
@@ -152,12 +171,25 @@ TEST_F(SVGTest, LayoutTest)
     EXPECT_TRUE(circleStrBottomLeft.find("cy=\"100\"") != std::string::npos);
 }
 
-// SimpleSvgTest -----------------------------------------------------------------------------------
+// SimpleSvgTest
+// -----------------------------------------------------------------------------------
+
+TEST(SimpleSvgTest, PointSizeAndBoxTest)
+{
+    Point p1(10, 20);
+    Size s1(50, 60);
+    Box b1(p1, s1);
+    EXPECT_EQ(b1.origin.x, 10);
+    EXPECT_EQ(b1.origin.y, 20);
+    EXPECT_EQ(b1.size.width, 50);
+    EXPECT_EQ(b1.size.height, 60);
+}
 
 TEST(SimpleSvgTest, TextTest)
 {
     Document doc;
-    doc << Text(Point(10, 20), "Hello, SVG!", Fill(Color::Black), Font(12, "Arial"));
+    doc << Text(Point(10, 20), "Hello, SVG!", Fill(Color::Black),
+                Font(12, "Arial"));
     std::string docStr = doc.toString();
 
     // std::cout << "TextTest SVG:\n"
@@ -172,13 +204,15 @@ TEST(SimpleSvgTest, TextTest)
 TEST(SimpleSvgTest, CircleTest)
 {
     Document doc;
-    doc << Circle(Point(100, 100), 50, Fill(Color::Red), Stroke(2, Color::Blue));
+    doc << Circle(Point(100, 100), 50, Fill(Color::Red),
+                  Stroke(2, Color::Blue));
     std::string docStr = doc.toString();
 
     // std::cout << "CircleTest SVG:\n"
     //           << docStr << std::endl;
 
-    EXPECT_TRUE(docStr.find("<circle cx=\"100\" cy=\"200\" r=\"25\"") != std::string::npos); // WHY cy="200"?
+    EXPECT_TRUE(docStr.find("<circle cx=\"100\" cy=\"200\" r=\"25\"") !=
+                std::string::npos);  // WHY cy="200"?
     EXPECT_TRUE(docStr.find("fill=\"rgb(255,0,0)\"") != std::string::npos);
     EXPECT_TRUE(docStr.find("stroke=\"rgb(0,0,255)\"") != std::string::npos);
     EXPECT_TRUE(docStr.find("stroke-width=\"2\"") != std::string::npos);
@@ -196,7 +230,9 @@ TEST(SimpleSvgTest, PolygonTest)
     // std::cout << "PolygonTest SVG:\n"
     //           << docStr << std::endl;
 
-    EXPECT_TRUE(docStr.find("<polygon points=\"0,300 100,300 100,200 0,200 \"") != std::string::npos);
+    EXPECT_TRUE(
+        docStr.find("<polygon points=\"0,300 100,300 100,200 0,200 \"") !=
+        std::string::npos);
     EXPECT_TRUE(docStr.find("fill=\"rgb(0,128,0)\"") != std::string::npos);
     EXPECT_TRUE(docStr.find("stroke=\"rgb(0,0,0)\"") != std::string::npos);
 }
@@ -215,7 +251,7 @@ TEST(SimpleSvgTest, LineChartTest)
     EXPECT_TRUE(docStr.find("<polyline") != std::string::npos);
     EXPECT_TRUE(docStr.find("stroke=\"rgb(0,0,255)\"") != std::string::npos);
     EXPECT_TRUE(docStr.find("stroke=\"rgb(255,0,0)\"") != std::string::npos);
-    EXPECT_TRUE(docStr.find("<circle") != std::string::npos); // Vertices
+    EXPECT_TRUE(docStr.find("<circle") != std::string::npos);  // Vertices
 }
 
 TEST(SimpleSvgTest, StrokeTest)
@@ -228,7 +264,9 @@ TEST(SimpleSvgTest, StrokeTest)
     // std::cout << "StrokeTest SVG:\n"
     //           << docStr << std::endl;
 
-    EXPECT_TRUE(docStr.find("rect x=\"0\" y=\"300\" width=\"100\" height=\"100\"") != std::string::npos);
+    EXPECT_TRUE(
+        docStr.find("rect x=\"0\" y=\"200\" width=\"100\" height=\"100\"") !=
+        std::string::npos);
     EXPECT_TRUE(docStr.find("height=\"100\"") != std::string::npos);
     EXPECT_TRUE(docStr.find("fill=\"none\"") != std::string::npos);
     EXPECT_TRUE(docStr.find("stroke-width=\"3\"") != std::string::npos);
@@ -249,7 +287,8 @@ TEST(SimpleSvgTest, PointTest)
     EXPECT_EQ(diff.y, 12);
 }
 
-// Run the tests -----------------------------------------------------------------------------------
+// Run the tests
+// -----------------------------------------------------------------------------------
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION

- add `.git-hooks/pre-commit` that performs `clang-format` on files to be committed 
- the developer should copy `.git-hooks/pre-commit` to his `.git/hooks` 
- update `README.md` 
- fix `cppcheck` problems
- Rectangle::toString: fix the coordinate transformations for Layouts 
- Text: use the approximate boundingBox to fix the origin depending on Layout 
- demo: add `Elipse` instance
- add `PointSizeAndBoxTest`